### PR TITLE
fix vercel deployment - include built app dist files

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,21 @@
+# Vercel Ignore File
+# This overrides .gitignore for Vercel deployments
+# We need to include built dist files even though they're gitignored
+
+# Don't ignore dist directories - we need them for deployment
+!packages/*/dist
+!packages/*/dist/**
+!verticals/*/dist
+!verticals/*/dist/**
+
+# Don't ignore compiled migration files
+!packages/core/migrations/*.js
+
+# Still ignore these
+node_modules
+.env
+.env.local
+*.log
+.DS_Store
+*.png
+Screenshot*.png

--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,11 @@
   "installCommand": "npm ci",
   "outputDirectory": "packages/web/dist",
   "framework": null,
+  "functions": {
+    "api/index.ts": {
+      "includeFiles": "packages/app/dist/**"
+    }
+  },
   "env": {
     "NODE_ENV": "production"
   },


### PR DESCRIPTION
- Add .vercelignore to explicitly include dist directories
- Configure functions.includeFiles in vercel.json for api/index.ts
- Ensures packages/app/dist/server.js is available at runtime
- Fixes 'Cannot find module ../packages/app/dist/server.js' error