### PR TITLE
fix: resolve Vercel deployment errors with CommonJS compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,4 @@ packages/core/migrations/*.d.ts.map
 .DS_Store
 *.png
 api/_server/
+dist-vercel/

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "deploy:staging": "vercel --env NODE_ENV=staging --env DATABASE_URL=$STAGING_DATABASE_URL",
     "deploy:production": "vercel --prod --env NODE_ENV=production --env DATABASE_URL=$DATABASE_URL",
     "deploy:preview": "vercel",
-    "vercel:build": "npm run build && npm run vercel:prepare",
-    "vercel:prepare": "mkdir -p api/_server && cp -r packages/app/dist/src/* api/_server/ && cp -r verticals/*/dist api/_server/ 2>/dev/null || true && cp -r packages/core/dist api/_server/ 2>/dev/null || true",
+    "vercel:build": "npm run build && cd packages/app && npm run build:vercel && cd ../.. && npm run vercel:prepare",
+    "vercel:prepare": "mkdir -p api/_server && cp -r packages/app/dist-vercel/src/* api/_server/ && cp -r verticals/*/dist api/_server/ 2>/dev/null || true && cp -r packages/core/dist api/_server/ 2>/dev/null || true",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/packages/app/eslint.config.js
+++ b/packages/app/eslint.config.js
@@ -85,7 +85,7 @@ export default [
       'unicorn/no-null': 'off', // SQL deals with null
       'unicorn/prefer-module': 'error',
       'unicorn/prefer-node-protocol': 'error',
-      'unicorn/prefer-top-level-await': 'error',
+      'unicorn/prefer-top-level-await': 'off', // Not compatible with CommonJS builds
       'unicorn/no-array-for-each': 'error',
       'unicorn/no-useless-undefined': 'error',
       'unicorn/explicit-length-check': 'error',
@@ -103,6 +103,7 @@ export default [
   {
     ignores: [
       'dist/',
+      'dist-vercel/',
       '*.js',
       '*.d.ts',
       '*.js.map',

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -9,11 +9,12 @@
     "dev": "node --watch --import tsx --no-warnings src/server.ts",
     "dev:watch": "tsc --watch",
     "build": "tsc",
+    "build:vercel": "tsc -p tsconfig.vercel.json",
     "start": "node dist/server.js",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint . --ext ts --max-warnings 0"
+    "lint": "eslint . --ext ts --max-warnings 0 --ignore-pattern 'dist-vercel/**'"
   },
   "dependencies": {
     "@care-commons/billing-invoicing": "*",

--- a/packages/app/src/server.ts
+++ b/packages/app/src/server.ts
@@ -287,6 +287,8 @@ process.on('SIGINT', () => {
 
 // Only start the server if this file is run directly (not imported)
 // This allows Vercel to import createApp() without starting a server
-if (import.meta.url === `file://${process.argv[1]}`) {
-  await start();
+// Check if running in Vercel environment
+if (process.env['VERCEL'] === undefined && process.env['VERCEL_ENV'] === undefined) {
+  // Not in Vercel, start the server for local development
+  void start().catch(console.error);
 }

--- a/packages/app/tsconfig.vercel.json
+++ b/packages/app/tsconfig.vercel.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "outDir": "./dist-vercel"
+  }
+}


### PR DESCRIPTION
- Changed buildCommand in vercel.json to use vercel:build script
- Created separate tsconfig.vercel.json to compile API as CommonJS for Vercel
- Updated vercel:prepare script to copy from dist-vercel directory
- Replaced import.meta.url check with environment variable check for Vercel detection
- Added dist-vercel to gitignore and eslint ignore patterns
- Fixed lint warnings for unicorn/prefer-top-level-await compatibility