### PR TITLE
Improve showcase UX: reduce visual clutter and add README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 
 **Care Commons** is a modular, self-hostable software platform designed to support the administration and daily operations of home-based care services. Built by the people at **Neighborhood Lab**.
 
-[Care Commons](https://care-commons.vercel.app/) (web application demo)
+**[🎮 Interactive Showcase](https://neighborhood-lab.github.io/care-commons/)** - Experience the platform through realistic scenarios  
+[Care Commons Web App](https://care-commons.vercel.app/) (full application demo)
 
 [Discord](https://discord.gg/EkeXQZFq)
 [Substack](https://neighborhoodlab.substack.com/) (updates, news and commentary)  

--- a/packages/web/src/showcase/ShowcaseRouter.tsx
+++ b/packages/web/src/showcase/ShowcaseRouter.tsx
@@ -262,11 +262,11 @@ export const ShowcaseRouter: React.FC = () => {
         {/* Scenario Container */}
         <ScenarioContainer />
 
-        {/* Tour FAB Button */}
-        <TourButton currentRole={currentRole} />
+        {/* Tour FAB Button - Only show after role selected */}
+        {currentRole && <TourButton currentRole={currentRole} />}
 
-        {/* Scenario FAB Button */}
-        <ScenarioButton />
+        {/* Scenario FAB Button - Only show after role selected */}
+        {currentRole && <ScenarioButton />}
       </ScenarioProvider>
     </TourProvider>
   );


### PR DESCRIPTION
## Summary
- Adds prominent Interactive Showcase link to README
- Hides tour and scenario FAB buttons until role is selected
- Reduces overwhelming first-time visitor experience
- Cleaner, less busy interface

## Changes
**README.md**
- Added emoji-highlighted showcase link at top
- Links to https://neighborhood-lab.github.io/care-commons/

**ShowcaseRouter.tsx**
- Conditionally render FAB buttons only when `currentRole` is set
- Prevents buttons from appearing on landing/welcome screens

## Testing
- Typecheck passes
- Improves issues visible in screenshots (overlapping modals/tours)

## Before
Multiple FAB buttons visible immediately, overlapping with welcome modal

## After  
Clean landing experience, buttons appear after role selection