### PR TITLE
Improve demo mode UX for preview deployment

### DIFF
--- a/packages/web/src/app/pages/Login.tsx
+++ b/packages/web/src/app/pages/Login.tsx
@@ -57,6 +57,28 @@ export const Login: React.FC = () => {
             Enter your credentials to access the platform
           </p>
         </div>
+
+        {/* Demo Credentials Info */}
+        <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+          <div className="flex items-start gap-3">
+            <div className="flex-shrink-0">
+              <svg className="h-5 w-5 text-blue-600" fill="currentColor" viewBox="0 0 20 20">
+                <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
+              </svg>
+            </div>
+            <div className="flex-1">
+              <h3 className="text-sm font-medium text-blue-900">Demo Credentials</h3>
+              <p className="mt-1 text-sm text-blue-700">
+                Email: <span className="font-mono">admin@carecommons.example</span><br />
+                Password: <span className="font-mono">Admin123!</span>
+              </p>
+              <p className="mt-2 text-xs text-blue-600">
+                Try the platform with sample data. <a href="https://neighborhood-lab.github.io/care-commons/" className="underline" target="_blank" rel="noopener noreferrer">View Interactive Showcase</a>
+              </p>
+            </div>
+          </div>
+        </div>
+
         <form className="mt-8 space-y-6" onSubmit={handleSubmit(onSubmit)}>
           <div className="space-y-4">
             <Input

--- a/packages/web/src/demo/DemoModeBar.tsx
+++ b/packages/web/src/demo/DemoModeBar.tsx
@@ -24,14 +24,14 @@ export function DemoModeBar() {
     return (
       <div className="bg-blue-600 text-white px-4 py-2 flex items-center justify-between shadow-md">
         <div className="flex items-center gap-3">
-          <span className="font-bold text-sm">DEMO MODE AVAILABLE</span>
-          <span className="text-xs opacity-90">Experience the platform with interactive demo data</span>
+          <span className="font-bold text-sm">DEMO MODE</span>
+          <span className="text-xs opacity-90">Try the platform with sample data • No real PHI</span>
         </div>
         <button
           onClick={() => void createSession()}
           className="bg-white text-blue-600 px-4 py-1 rounded text-sm font-medium hover:bg-blue-50 transition-colors"
         >
-          Start Demo
+          Start Demo Session
         </button>
       </div>
     );
@@ -86,7 +86,7 @@ export function DemoModeBar() {
             <div>
               <h4 className="font-semibold text-sm mb-2">Switch Persona</h4>
               <div className="grid grid-cols-2 gap-2">
-                {session.availablePersonas.map((persona) => (
+                {session.availablePersonas?.map((persona) => (
                   <button
                     key={persona.id}
                     onClick={() => void switchPersona(persona.type)}


### PR DESCRIPTION
## Summary
Makes preview deployment ready for real users by clarifying demo mode and providing clear instructions.

## Changes

**Login Page**
- Added demo credentials info box (blue banner)
- Shows: `admin@carecommons.example` / `Admin123!`  
- Links to interactive showcase
- Makes it obvious how to try the platform

**Demo Mode Bar**
- Fixed crash when `availablePersonas` is undefined (optional chaining)
- Improved messaging: "Try the platform with sample data • No real PHI"
- Better CTA: "Start Demo Session" (was "Start Demo")

## Testing
- Typecheck passes
- Fixes console error from screenshot 3
- Makes demo mode purpose crystal clear

## Why
Preview deployment is on Vercel Hobby - can only support demo users. This makes it clear this is a demo environment with sample data, not production.

## Follow-up
Could add: Link back to showcase from app header