### PR TITLE
Simplify UI design with minimal colors and text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/@acemir/cssom": {
-      "version": "0.9.19",
-      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.19.tgz",
-      "integrity": "sha512-Pp2gAQXPZ2o7lt4j0IMwNRXqQ3pagxtDj5wctL5U2Lz4oV0ocDNlkgx4DpxfyKav4S/bePuI+SMqcBSUHLy9kg==",
+      "version": "0.9.20",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.20.tgz",
+      "integrity": "sha512-YUSA5jW8qn/c6nZUlFsn2Nt5qFFRBcGTgL9CzbiZbJCtEFY0Nv/ycO3BHT9tLjus9++zOYWe5mLCRIesuay25g==",
       "dev": true,
       "license": "MIT"
     },
@@ -15040,9 +15040,9 @@
       }
     },
     "node_modules/react-native-worklets": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.5.2.tgz",
-      "integrity": "sha512-lCzmuIPAK/UaOJYEPgYpVqrsxby1I54f7PyyZUMEO04nwc00CDrCvv9lCTY1daLHYTF8lS3f9zlzErfVsIKqkA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.6.1.tgz",
+      "integrity": "sha512-URca8l7c7Uog7gv4mcg9KILdJlnbvwdS5yfXQYf5TDkD2W1VY1sduEKrD+sA3lUPXH/TG1vmXAvNxCNwPMYgGg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -17810,9 +17810,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.0.tgz",
-      "integrity": "sha512-C/Naxf8H0pBx1PA4BdpT+c/5wdqI9ILMdwjSMILw7tVIh3JsxzZqdeTLmmdaoh5MYUEOyBnM9K3o0DzoZ/fe+w==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.1.tgz",
+      "integrity": "sha512-qTl3VF7BvOupTR85Zc561sPEgxyUSNSvTQ9fit7DEMP7yPgvvIGm5Zfa1dOM+kOwWGNviK9uFM9ra77+OjK7lQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/web/src/core/components/showcase/RoleSwitcher.tsx
+++ b/packages/web/src/core/components/showcase/RoleSwitcher.tsx
@@ -10,10 +10,10 @@ import { useApiProvider } from '../../providers';
 import { ShowcaseApiProvider } from '../../providers/showcase-api-provider';
 
 const ROLES = [
-  { id: 'ADMIN', label: 'Admin', description: 'Full system access' },
-  { id: 'COORDINATOR', label: 'Care Coordinator', description: 'Manage clients and care plans' },
-  { id: 'CAREGIVER', label: 'Caregiver', description: 'View assignments and log time' },
-  { id: 'BILLING', label: 'Billing Manager', description: 'Manage billing and payroll' },
+  { id: 'ADMIN', label: 'Admin' },
+  { id: 'COORDINATOR', label: 'Care Coordinator' },
+  { id: 'CAREGIVER', label: 'Caregiver' },
+  { id: 'BILLING', label: 'Billing Manager' },
 ];
 
 export const RoleSwitcher: React.FC = () => {
@@ -37,12 +37,12 @@ export const RoleSwitcher: React.FC = () => {
     <div className="relative">
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-2 px-3 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors"
+        className="flex items-center gap-2 px-3 py-2 bg-gray-900 text-white rounded-lg hover:bg-gray-800 transition-colors"
         title="Switch Role"
       >
         <Users className="h-4 w-4" />
         <span className="text-sm font-medium">
-          {ROLES.find(r => r.id === currentRole)?.label || 'Switch Role'}
+          {ROLES.find(r => r.id === currentRole)?.label || 'Care Coordinator'}
         </span>
       </button>
 
@@ -52,22 +52,17 @@ export const RoleSwitcher: React.FC = () => {
             className="fixed inset-0 z-40"
             onClick={() => setIsOpen(false)}
           />
-          <div className="absolute right-0 mt-2 w-64 bg-white rounded-lg shadow-lg border border-gray-200 z-50">
-            <div className="p-3 border-b border-gray-200">
-              <h3 className="font-semibold text-gray-900">Switch Role</h3>
-              <p className="text-xs text-gray-600 mt-1">View the app from different perspectives</p>
-            </div>
+          <div className="absolute right-0 mt-2 w-56 bg-white rounded-lg shadow-lg border border-gray-200 z-50">
             <div className="p-2">
               {ROLES.map(role => (
                 <button
                   key={role.id}
                   onClick={() => handleRoleSwitch(role.id)}
                   className={`w-full text-left px-3 py-2 rounded hover:bg-gray-100 transition-colors ${
-                    currentRole === role.id ? 'bg-purple-50 text-purple-700' : 'text-gray-700'
+                    currentRole === role.id ? 'bg-gray-900 text-white' : 'text-gray-700'
                   }`}
                 >
-                  <div className="font-medium">{role.label}</div>
-                  <div className="text-xs text-gray-600">{role.description}</div>
+                  {role.label}
                 </button>
               ))}
             </div>

--- a/packages/web/src/core/components/showcase/ShowcaseControls.tsx
+++ b/packages/web/src/core/components/showcase/ShowcaseControls.tsx
@@ -30,16 +30,16 @@ export const ShowcaseControls: React.FC = () => {
       <div className="fixed top-4 right-4 z-50 flex items-center gap-2">
         <button
           onClick={() => setShowInfo(true)}
-          className="flex items-center gap-2 px-3 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
-          title="About This Demo"
+          className="flex items-center gap-2 px-3 py-2 bg-gray-900 text-white rounded-lg hover:bg-gray-800 transition-colors"
+          title="About"
         >
           <Info className="h-4 w-4" />
         </button>
 
         <button
           onClick={handleReset}
-          className="flex items-center gap-2 px-3 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors"
-          title="Reset Demo Data"
+          className="flex items-center gap-2 px-3 py-2 bg-gray-900 text-white rounded-lg hover:bg-gray-800 transition-colors"
+          title="Reset Data"
         >
           <RotateCcw className="h-4 w-4" />
           <span className="text-sm font-medium">Reset Data</span>
@@ -49,12 +49,8 @@ export const ShowcaseControls: React.FC = () => {
       </div>
 
       {/* Demo Info Banner */}
-      <div className="fixed top-16 left-0 right-0 z-40 bg-gradient-to-r from-purple-600 to-blue-600 text-white px-4 py-2 text-center text-sm shadow-lg">
-        <span className="font-semibold">Demo Mode</span>
-        <span className="mx-2">•</span>
-        <span>All changes are saved locally in your browser</span>
-        <span className="mx-2">•</span>
-        <span>Try switching roles to see different perspectives</span>
+      <div className="fixed top-16 left-0 right-0 z-40 bg-gray-900 text-white px-4 py-2 text-center text-sm">
+        <span>Demo Mode • Changes saved locally</span>
       </div>
 
       {/* Info Modal */}
@@ -65,10 +61,10 @@ export const ShowcaseControls: React.FC = () => {
             onClick={() => setShowInfo(false)}
           />
           <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-            <div className="bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
+            <div className="bg-white rounded-lg shadow-xl max-w-lg w-full">
               <div className="p-6">
                 <div className="flex items-center justify-between mb-4">
-                  <h2 className="text-2xl font-bold text-gray-900">About This Demo</h2>
+                  <h2 className="text-2xl font-bold text-gray-900">About</h2>
                   <button
                     onClick={() => setShowInfo(false)}
                     className="text-gray-400 hover:text-gray-600"
@@ -79,75 +75,31 @@ export const ShowcaseControls: React.FC = () => {
 
                 <div className="space-y-4 text-gray-700">
                   <p>
-                    Welcome to the <strong>Care Commons Platform</strong> interactive demo!
-                    This showcase runs entirely in your browser and demonstrates the full
-                    capabilities of our community-owned care coordination software.
+                    Interactive demo of Care Commons care coordination software.
                   </p>
 
-                  <div>
-                    <h3 className="font-semibold text-gray-900 mb-2">Features You Can Explore:</h3>
-                    <ul className="list-disc list-inside space-y-1 ml-2">
-                      <li>Client Demographics & Management</li>
-                      <li>Care Plan Creation & Tracking</li>
-                      <li>Task Management & Assignments</li>
-                      <li>Shift Matching & Scheduling</li>
-                      <li>Electronic Visit Verification (EVV)</li>
-                      <li>Billing & Invoicing</li>
-                      <li>Payroll Processing</li>
-                    </ul>
-                  </div>
-
-                  <div>
-                    <h3 className="font-semibold text-gray-900 mb-2">Try Different Roles:</h3>
-                    <ul className="list-disc list-inside space-y-1 ml-2">
-                      <li><strong>Admin:</strong> Full system access and configuration</li>
-                      <li><strong>Care Coordinator:</strong> Manage clients, care plans, and assignments</li>
-                      <li><strong>Caregiver:</strong> View shifts, log time, and complete tasks</li>
-                      <li><strong>Family Member:</strong> View care updates and communicate</li>
-                    </ul>
-                  </div>
-
-                  <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-                    <h3 className="font-semibold text-blue-900 mb-2">How It Works:</h3>
-                    <p className="text-blue-800 text-sm">
-                      This demo uses your browser's local storage to save changes. Each visitor
-                      gets their own sandbox to experiment with. Your changes won't affect anyone
-                      else, and you can reset the data anytime using the "Reset Data" button.
-                    </p>
-                  </div>
-
-                  <div>
-                    <h3 className="font-semibold text-gray-900 mb-2">Demo Credentials:</h3>
-                    <div className="bg-gray-50 rounded p-3 text-sm font-mono">
-                      <div>Email: coordinator@demo.care-commons.org</div>
-                      <div>Password: demo</div>
-                    </div>
-                    <p className="text-xs text-gray-600 mt-2">
-                      (Or use the Role Switcher to instantly switch perspectives)
-                    </p>
-                  </div>
+                  <p className="text-sm">
+                    Changes are saved in your browser. Use Role Switcher to view different perspectives.
+                  </p>
 
                   <div className="pt-4 border-t border-gray-200">
-                    <p className="text-sm text-gray-600">
-                      Want to learn more or contribute?{' '}
-                      <a
-                        href="https://github.com/neighborhood-lab/care-commons"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-blue-600 hover:text-blue-800 font-medium"
-                      >
-                        Visit our GitHub repository
-                      </a>
-                    </p>
+                    <a
+                      href="https://github.com/neighborhood-lab/care-commons"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-gray-900 hover:text-gray-700 font-medium"
+                    >
+                      GitHub →
+                    </a>
                   </div>
                 </div>
 
                 <div className="mt-6 flex justify-end">
                   <button
                     onClick={() => setShowInfo(false)}
-                    className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+                    className="px-6 py-2 bg-gray-900 text-white rounded-lg hover:bg-gray-800 transition-colors"
                   >
-                    Got it!
+                    Close
                   </button>
                 </div>
               </div>

--- a/packages/web/src/showcase/ShowcaseRouter.tsx
+++ b/packages/web/src/showcase/ShowcaseRouter.tsx
@@ -67,7 +67,6 @@ export const ShowcaseRouter: React.FC = () => {
             path="/"
             element={
               <EnhancedLandingPage
-                onSelectRole={handleRoleSelect}
                 onStartTour={handleStartTour}
               />
             }

--- a/packages/web/src/showcase/components/onboarding/EnhancedRoleSelector.tsx
+++ b/packages/web/src/showcase/components/onboarding/EnhancedRoleSelector.tsx
@@ -4,8 +4,8 @@
  * Full-screen role selection experience with detailed persona information
  */
 
-import React, { useState } from 'react';
-import { X, Clock, BarChart3, ArrowRight, Search } from 'lucide-react';
+import React from 'react';
+import { X } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { personas } from '../../data/personas';
 
@@ -22,25 +22,9 @@ export const EnhancedRoleSelector: React.FC<EnhancedRoleSelectorProps> = ({
   onSelectRole,
   currentRole,
 }) => {
-  const [searchTerm, setSearchTerm] = useState('');
-  const [selectedPersona, setSelectedPersona] = useState<string | null>(null);
-
-  const filteredPersonas = personas.filter((persona) =>
-    persona.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    persona.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    persona.features.some(f => f.toLowerCase().includes(searchTerm.toLowerCase()))
-  );
-
   const handleSelectRole = (roleId: string) => {
     onSelectRole(roleId);
     onClose();
-  };
-
-  const handleSurpriseMe = () => {
-    const randomPersona = personas[Math.floor(Math.random() * personas.length)];
-    if (randomPersona) {
-      handleSelectRole(randomPersona.id);
-    }
   };
 
   if (!isOpen) return null;
@@ -63,67 +47,34 @@ export const EnhancedRoleSelector: React.FC<EnhancedRoleSelectorProps> = ({
             initial={{ opacity: 0, scale: 0.95 }}
             animate={{ opacity: 1, scale: 1 }}
             exit={{ opacity: 0, scale: 0.95 }}
-            className="relative bg-white rounded-xl shadow-2xl max-w-6xl w-full max-h-[90vh] overflow-hidden"
+            className="relative bg-white rounded-xl shadow-2xl max-w-3xl w-full max-h-[90vh] overflow-hidden"
           >
             {/* Header */}
-            <div className="bg-gradient-to-r from-purple-600 to-blue-600 p-6">
-              <div className="flex items-center justify-between mb-4">
-                <div>
-                  <h2 className="text-3xl font-bold text-white">Choose Your Perspective</h2>
-                  <p className="text-purple-100 mt-1">
-                    Explore the platform from different user roles
-                  </p>
-                </div>
+            <div className="bg-gray-900 p-6">
+              <div className="flex items-center justify-between">
+                <h2 className="text-2xl font-bold text-white">Choose Role</h2>
                 <button
                   onClick={onClose}
-                  className="text-white hover:text-gray-200 transition-colors"
+                  className="text-white hover:text-gray-300 transition-colors"
                   aria-label="Close"
                 >
                   <X className="h-6 w-6" />
                 </button>
               </div>
-
-              {/* Search and Actions */}
-              <div className="flex flex-col sm:flex-row gap-3">
-                <div className="flex-1 relative">
-                  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
-                  <input
-                    type="text"
-                    placeholder="Search by role or feature..."
-                    value={searchTerm}
-                    onChange={(e) => setSearchTerm(e.target.value)}
-                    className="w-full pl-10 pr-4 py-2 rounded-lg border-0 focus:ring-2 focus:ring-white"
-                  />
-                </div>
-                <button
-                  onClick={handleSurpriseMe}
-                  className="px-6 py-2 bg-white text-purple-600 rounded-lg font-semibold hover:bg-gray-100 transition-colors"
-                >
-                  🎲 Surprise Me!
-                </button>
-              </div>
             </div>
 
             {/* Persona Grid */}
-            <div className="p-6 overflow-y-auto max-h-[calc(90vh-200px)]">
-              {filteredPersonas.length === 0 ? (
-                <div className="text-center py-12">
-                  <p className="text-gray-500 text-lg">No personas found matching your search.</p>
-                </div>
-              ) : (
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                  {filteredPersonas.map((persona) => (
-                    <PersonaDetailCard
-                      key={persona.id}
-                      persona={persona}
-                      isSelected={selectedPersona === persona.id}
-                      isCurrent={currentRole === persona.id}
-                      onSelect={() => setSelectedPersona(persona.id)}
-                      onConfirm={() => handleSelectRole(persona.id)}
-                    />
-                  ))}
-                </div>
-              )}
+            <div className="p-8 overflow-y-auto max-h-[calc(90vh-120px)]">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                {personas.map((persona) => (
+                  <PersonaDetailCard
+                    key={persona.id}
+                    persona={persona}
+                    isCurrent={currentRole === persona.id}
+                    onConfirm={() => handleSelectRole(persona.id)}
+                  />
+                ))}
+              </div>
             </div>
           </motion.div>
         </div>
@@ -134,122 +85,44 @@ export const EnhancedRoleSelector: React.FC<EnhancedRoleSelectorProps> = ({
 
 interface PersonaDetailCardProps {
   persona: any;
-  isSelected: boolean;
   isCurrent: boolean;
-  onSelect: () => void;
   onConfirm: () => void;
 }
 
 const PersonaDetailCard: React.FC<PersonaDetailCardProps> = ({
   persona,
-  isSelected,
   isCurrent,
-  onSelect,
   onConfirm,
 }) => {
-  const difficultyColors: Record<string, string> = {
-    beginner: 'green',
-    intermediate: 'yellow',
-    advanced: 'red',
-  };
-
-  const difficultyColor = difficultyColors[persona.difficulty];
-
   return (
-    <motion.div
-      whileHover={{ scale: 1.02 }}
-      className={`relative bg-white rounded-lg border-2 transition-all cursor-pointer ${
-        isSelected
-          ? `border-${persona.color}-500 shadow-lg`
-          : isCurrent
-          ? 'border-purple-300 bg-purple-50'
-          : 'border-gray-200 hover:border-gray-300'
+    <button
+      onClick={onConfirm}
+      disabled={isCurrent}
+      className={`relative text-left p-6 rounded-lg border-2 transition-all ${
+        isCurrent
+          ? 'border-gray-900 bg-gray-50 opacity-50 cursor-not-allowed'
+          : 'border-gray-200 hover:border-gray-900'
       }`}
-      onClick={onSelect}
     >
+      <div className="flex items-center gap-4">
+        <div className="w-12 h-12 rounded-full bg-gray-100 flex items-center justify-center flex-shrink-0">
+          <span className="text-2xl">
+            {persona.id === 'admin' && '👨‍💼'}
+            {persona.id === 'coordinator' && '👩‍⚕️'}
+            {persona.id === 'caregiver' && '👩‍🔬'}
+            {persona.id === 'patient' && '👵'}
+          </span>
+        </div>
+        <div className="flex-1">
+          <h3 className="text-lg font-bold text-gray-900">{persona.name}</h3>
+          <p className="text-sm text-gray-600">{persona.title}</p>
+        </div>
+      </div>
       {isCurrent && (
-        <div className="absolute top-3 right-3 px-3 py-1 bg-purple-600 text-white text-xs font-semibold rounded-full">
-          Current Role
+        <div className="mt-3 text-xs text-gray-600">
+          Current
         </div>
       )}
-
-      <div className="p-6">
-        {/* Avatar and Basic Info */}
-        <div className="flex items-start gap-4 mb-4">
-          <div className={`w-16 h-16 rounded-full bg-${persona.color}-100 flex items-center justify-center flex-shrink-0`}>
-            <span className="text-3xl">
-              {persona.id === 'admin' && '👨‍💼'}
-              {persona.id === 'coordinator' && '👩‍⚕️'}
-              {persona.id === 'caregiver' && '👩‍🔬'}
-              {persona.id === 'patient' && '👵'}
-            </span>
-          </div>
-          <div className="flex-1">
-            <h3 className="text-xl font-bold text-gray-900">{persona.name}</h3>
-            <p className="text-sm text-gray-600">{persona.title}</p>
-            <div className="flex items-center gap-2 mt-2">
-              <div className={`inline-block px-2 py-1 bg-${persona.color}-100 text-${persona.color}-700 rounded text-xs font-semibold`}>
-                {persona.id}
-              </div>
-              <div className={`inline-block px-2 py-1 bg-${difficultyColor}-100 text-${difficultyColor}-700 rounded text-xs font-semibold`}>
-                {persona.difficulty}
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {/* Mission */}
-        <div className="mb-4">
-          <h4 className="text-sm font-semibold text-gray-700 mb-1">Today's Mission:</h4>
-          <p className="text-sm text-gray-600">{persona.missionTitle}</p>
-        </div>
-
-        {/* Metadata */}
-        <div className="flex items-center gap-4 text-sm text-gray-600 mb-4">
-          <div className="flex items-center gap-1">
-            <Clock className="h-4 w-4" />
-            <span>{persona.estimatedTime} min</span>
-          </div>
-          <div className="flex items-center gap-1">
-            <BarChart3 className="h-4 w-4" />
-            <span>{persona.features.length} features</span>
-          </div>
-        </div>
-
-        {/* Features List */}
-        <div className="mb-4">
-          <h4 className="text-sm font-semibold text-gray-700 mb-2">Key Features:</h4>
-          <ul className="space-y-1">
-            {persona.features.slice(0, 3).map((feature: string, index: number) => (
-              <li key={index} className="text-sm text-gray-600 flex items-start gap-2">
-                <span className="text-green-500 mt-0.5">✓</span>
-                <span>{feature}</span>
-              </li>
-            ))}
-            {persona.features.length > 3 && (
-              <li className="text-sm text-gray-500 italic">
-                +{persona.features.length - 3} more features...
-              </li>
-            )}
-          </ul>
-        </div>
-
-        {/* Action Button */}
-        {isSelected && (
-          <motion.button
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-            onClick={(e: React.MouseEvent) => {
-              e.stopPropagation();
-              onConfirm();
-            }}
-            className={`w-full py-3 bg-gradient-to-r from-${persona.color}-600 to-${persona.color}-700 text-white rounded-lg font-semibold hover:from-${persona.color}-700 hover:to-${persona.color}-800 transition-all flex items-center justify-center gap-2`}
-          >
-            Start as {persona.name}
-            <ArrowRight className="h-5 w-5" />
-          </motion.button>
-        )}
-      </div>
-    </motion.div>
+    </button>
   );
 };

--- a/packages/web/src/showcase/components/onboarding/WelcomeModal.tsx
+++ b/packages/web/src/showcase/components/onboarding/WelcomeModal.tsx
@@ -1,44 +1,14 @@
 /**
  * Welcome Modal for First-Time Visitors
  *
- * Multi-step onboarding flow that guides new visitors through the showcase
+ * Simple onboarding for new visitors
  */
 
 import React, { useState } from 'react';
-import { X, ChevronRight, ChevronLeft, Check } from 'lucide-react';
+import { X } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { personas } from '../../data/personas';
-import { PersonaRole } from '../../types';
 
 const STORAGE_KEY = 'care-commons-showcase-visited';
-
-// Color mapping for Tailwind classes (must be complete class names)
-const colorClasses = {
-  purple: {
-    border: 'border-purple-500',
-    bg: 'bg-purple-50',
-    bgDark: 'bg-purple-100',
-    text: 'text-purple-500',
-  },
-  blue: {
-    border: 'border-blue-500',
-    bg: 'bg-blue-50',
-    bgDark: 'bg-blue-100',
-    text: 'text-blue-500',
-  },
-  green: {
-    border: 'border-green-500',
-    bg: 'bg-green-50',
-    bgDark: 'bg-green-100',
-    text: 'text-green-500',
-  },
-  pink: {
-    border: 'border-pink-500',
-    bg: 'bg-pink-50',
-    bgDark: 'bg-pink-100',
-    text: 'text-pink-500',
-  },
-} as const;
 
 interface WelcomeModalProps {
   onComplete?: (selectedRole?: string) => void;
@@ -53,19 +23,8 @@ export const WelcomeModal: React.FC<WelcomeModalProps> = ({ onComplete }) => {
     }
     return false;
   });
-  const [currentStep, setCurrentStep] = useState(0);
-  const [selectedRole, setSelectedRole] = useState<PersonaRole | null>(null);
-  const [dontShowAgain, setDontShowAgain] = useState(false);
 
   const handleComplete = () => {
-    if (dontShowAgain && typeof window !== 'undefined') {
-      window.localStorage.setItem(STORAGE_KEY, 'true');
-    }
-    setIsOpen(false);
-    onComplete?.(selectedRole ?? undefined);
-  };
-
-  const handleSkip = () => {
     if (typeof window !== 'undefined') {
       window.localStorage.setItem(STORAGE_KEY, 'true');
     }
@@ -73,147 +32,7 @@ export const WelcomeModal: React.FC<WelcomeModalProps> = ({ onComplete }) => {
     onComplete?.();
   };
 
-  const steps = [
-    {
-      title: 'Welcome to Care Commons',
-      content: (
-        <div className="space-y-4">
-          <p className="text-lg text-gray-700">
-            Welcome to the <strong>Care Commons Interactive Demo</strong>!
-            This showcase runs entirely in your browser and demonstrates the full
-            capabilities of our community-owned care coordination platform.
-          </p>
-          <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-            <h4 className="font-semibold text-blue-900 mb-2">What makes this demo special?</h4>
-            <ul className="space-y-2 text-blue-800">
-              <li className="flex items-start gap-2">
-                <Check className="h-5 w-5 mt-0.5 flex-shrink-0" />
-                <span>Fully functional in-browser - no server required</span>
-              </li>
-              <li className="flex items-start gap-2">
-                <Check className="h-5 w-5 mt-0.5 flex-shrink-0" />
-                <span>Switch between roles anytime to see different perspectives</span>
-              </li>
-              <li className="flex items-start gap-2">
-                <Check className="h-5 w-5 mt-0.5 flex-shrink-0" />
-                <span>Realistic data and workflows based on real use cases</span>
-              </li>
-              <li className="flex items-start gap-2">
-                <Check className="h-5 w-5 mt-0.5 flex-shrink-0" />
-                <span>Mobile device simulation for caregiver workflows</span>
-              </li>
-            </ul>
-          </div>
-        </div>
-      ),
-    },
-    {
-      title: 'Choose Your Journey',
-      content: (
-        <div className="space-y-4">
-          <p className="text-gray-700">
-            Which perspective would you like to explore first?
-          </p>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-            {personas.map((persona) => {
-              const colors = colorClasses[persona.color as keyof typeof colorClasses] || colorClasses.blue;
-              return (
-                <button
-                  key={persona.id}
-                  onClick={() => setSelectedRole(persona.id)}
-                  className={`text-left p-4 rounded-lg border-2 transition-all ${
-                    selectedRole === persona.id
-                      ? `${colors.border} ${colors.bg}`
-                      : 'border-gray-200 hover:border-gray-300'
-                  }`}
-                >
-                  <div className="flex items-start gap-3">
-                    <div className={`w-12 h-12 rounded-full ${colors.bgDark} flex items-center justify-center flex-shrink-0`}>
-                      <span className="text-2xl">
-                        {persona.id === 'admin' && '👨‍💼'}
-                        {persona.id === 'coordinator' && '👩‍⚕️'}
-                        {persona.id === 'caregiver' && '👩‍🔬'}
-                        {persona.id === 'patient' && '👵'}
-                      </span>
-                    </div>
-                    <div className="flex-1">
-                      <h4 className="font-semibold text-gray-900">{persona.name}</h4>
-                      <p className="text-sm text-gray-600">{persona.title}</p>
-                      <p className="text-xs text-gray-500 mt-1">{persona.estimatedTime} min experience</p>
-                    </div>
-                    {selectedRole === persona.id && (
-                      <Check className={`h-5 w-5 ${colors.text}`} />
-                    )}
-                  </div>
-                </button>
-              );
-            })}
-          </div>
-        </div>
-      ),
-    },
-    {
-      title: 'Ready to Explore!',
-      content: (
-        <div className="space-y-4">
-          <p className="text-lg text-gray-700">
-            {selectedRole ? (
-              (() => {
-                const persona = personas.find(p => p.id === selectedRole);
-                return persona ? (
-                  <>You'll start as <strong>{persona.name}</strong> - {persona.title}</>
-                ) : (
-                  <>You're all set to explore the Care Commons platform!</>
-                );
-              })()
-            ) : (
-              <>You're all set to explore the Care Commons platform!</>
-            )}
-          </p>
-
-          <div className="bg-gradient-to-r from-purple-50 to-blue-50 border border-purple-200 rounded-lg p-4">
-            <h4 className="font-semibold text-purple-900 mb-3">Quick Tips:</h4>
-            <ul className="space-y-2 text-purple-800 text-sm">
-              <li className="flex items-start gap-2">
-                <span className="font-bold">💡</span>
-                <span>Use the <strong>Role Switcher</strong> (top right) to change perspectives anytime</span>
-              </li>
-              <li className="flex items-start gap-2">
-                <span className="font-bold">🔄</span>
-                <span>Click <strong>Reset Data</strong> to start fresh with original demo data</span>
-              </li>
-              <li className="flex items-start gap-2">
-                <span className="font-bold">💾</span>
-                <span>All changes are saved in your browser - your data won't affect others</span>
-              </li>
-              <li className="flex items-start gap-2">
-                <span className="font-bold">❓</span>
-                <span>Click the <strong>Info</strong> button for help anytime</span>
-              </li>
-            </ul>
-          </div>
-
-          <div className="flex items-center gap-2">
-            <input
-              type="checkbox"
-              id="dont-show"
-              checked={dontShowAgain}
-              onChange={(e) => setDontShowAgain(e.target.checked)}
-              className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-            />
-            <label htmlFor="dont-show" className="text-sm text-gray-600">
-              Don't show this welcome message again
-            </label>
-          </div>
-        </div>
-      ),
-    },
-  ];
-
   if (!isOpen) return null;
-
-  const currentStepData = steps[currentStep];
-  if (!currentStepData) return null;
 
   return (
     <AnimatePresence>
@@ -222,90 +41,34 @@ export const WelcomeModal: React.FC<WelcomeModalProps> = ({ onComplete }) => {
           initial={{ opacity: 0, scale: 0.95 }}
           animate={{ opacity: 1, scale: 1 }}
           exit={{ opacity: 0, scale: 0.95 }}
-          className="bg-white rounded-xl shadow-2xl max-w-3xl w-full max-h-[90vh] overflow-hidden"
+          className="bg-white rounded-xl shadow-2xl max-w-lg w-full overflow-hidden"
         >
           {/* Header */}
-          <div className="bg-gradient-to-r from-purple-600 to-blue-600 text-white p-6">
+          <div className="bg-gray-900 text-white p-6">
             <div className="flex items-center justify-between">
-              <div>
-                <h2 className="text-2xl font-bold">{currentStepData.title}</h2>
-                <p className="text-purple-100 text-sm mt-1">
-                  Step {currentStep + 1} of {steps.length}
-                </p>
-              </div>
+              <h2 className="text-2xl font-bold">Welcome</h2>
               <button
-                onClick={handleSkip}
-                className="text-white hover:text-gray-200 transition-colors"
+                onClick={handleComplete}
+                className="text-white hover:text-gray-300 transition-colors"
                 aria-label="Close"
               >
                 <X className="h-6 w-6" />
               </button>
             </div>
-
-            {/* Progress bar */}
-            <div className="mt-4 h-2 bg-white bg-opacity-20 rounded-full overflow-hidden">
-              <motion.div
-                className="h-full bg-white"
-                initial={{ width: 0 }}
-                animate={{ width: `${((currentStep + 1) / steps.length) * 100}%` }}
-                transition={{ duration: 0.3 }}
-              />
-            </div>
           </div>
 
           {/* Content */}
-          <div className="p-6 overflow-y-auto max-h-[60vh]">
-            <AnimatePresence mode="wait">
-              <motion.div
-                key={currentStep}
-                initial={{ opacity: 0, x: 20 }}
-                animate={{ opacity: 1, x: 0 }}
-                exit={{ opacity: 0, x: -20 }}
-                transition={{ duration: 0.2 }}
-              >
-                {currentStepData.content}
-              </motion.div>
-            </AnimatePresence>
-          </div>
+          <div className="p-8">
+            <p className="text-lg text-gray-700 mb-8">
+              This is an interactive demo of Care Commons care coordination software.
+            </p>
 
-          {/* Footer */}
-          <div className="border-t border-gray-200 p-6 bg-gray-50 flex items-center justify-between">
             <button
-              onClick={handleSkip}
-              className="text-gray-600 hover:text-gray-800 text-sm font-medium"
+              onClick={handleComplete}
+              className="w-full px-6 py-3 bg-gray-900 text-white rounded-lg hover:bg-gray-800 font-medium transition-colors"
             >
-              Skip tour
+              Start Exploring
             </button>
-
-            <div className="flex items-center gap-3">
-              {currentStep > 0 && (
-                <button
-                  onClick={() => setCurrentStep(currentStep - 1)}
-                  className="flex items-center gap-2 px-4 py-2 text-gray-700 hover:text-gray-900 font-medium transition-colors"
-                >
-                  <ChevronLeft className="h-4 w-4" />
-                  Previous
-                </button>
-              )}
-
-              {currentStep < steps.length - 1 ? (
-                <button
-                  onClick={() => setCurrentStep(currentStep + 1)}
-                  className="flex items-center gap-2 px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-medium transition-colors"
-                >
-                  Next
-                  <ChevronRight className="h-4 w-4" />
-                </button>
-              ) : (
-                <button
-                  onClick={handleComplete}
-                  className="flex items-center gap-2 px-6 py-2 bg-gradient-to-r from-purple-600 to-blue-600 text-white rounded-lg hover:from-purple-700 hover:to-blue-700 font-medium transition-colors"
-                >
-                  Start Exploring
-                  <ChevronRight className="h-4 w-4" />
-                </button>
-              )}
-            </div>
           </div>
         </motion.div>
       </div>

--- a/packages/web/src/showcase/pages/EnhancedLandingPage.tsx
+++ b/packages/web/src/showcase/pages/EnhancedLandingPage.tsx
@@ -8,12 +8,10 @@ import React from 'react';
 import { motion } from 'framer-motion';
 
 interface EnhancedLandingPageProps {
-  onSelectRole: (roleId: string) => void;
   onStartTour?: () => void;
 }
 
 export const EnhancedLandingPage: React.FC<EnhancedLandingPageProps> = ({
-  onSelectRole,
   onStartTour,
 }) => {
   return (

--- a/packages/web/src/showcase/pages/EnhancedLandingPage.tsx
+++ b/packages/web/src/showcase/pages/EnhancedLandingPage.tsx
@@ -6,8 +6,6 @@
 
 import React from 'react';
 import { motion } from 'framer-motion';
-import { ArrowRight, Shield, Zap, Globe, Users } from 'lucide-react';
-import { personas } from '../data/personas';
 
 interface EnhancedLandingPageProps {
   onSelectRole: (roleId: string) => void;
@@ -19,264 +17,35 @@ export const EnhancedLandingPage: React.FC<EnhancedLandingPageProps> = ({
   onStartTour,
 }) => {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-purple-50 via-blue-50 to-white">
+    <div className="min-h-screen bg-white">
       {/* Hero Section */}
       <div className="relative overflow-hidden">
-        {/* Background decoration */}
-        <div className="absolute inset-0 overflow-hidden">
-          <div className="absolute -top-40 -right-40 w-80 h-80 bg-purple-300 rounded-full mix-blend-multiply filter blur-3xl opacity-30 animate-blob" />
-          <div className="absolute -bottom-40 -left-40 w-80 h-80 bg-blue-300 rounded-full mix-blend-multiply filter blur-3xl opacity-30 animate-blob animation-delay-2000" />
-        </div>
-
-        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-20 pb-16">
+        <div className="relative max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pt-32 pb-24">
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6 }}
             className="text-center"
           >
-            {/* Logo/Badge */}
-            <motion.div
-              initial={{ scale: 0 }}
-              animate={{ scale: 1 }}
-              transition={{ delay: 0.2, type: 'spring', stiffness: 200 }}
-              className="inline-block mb-6"
-            >
-              <div className="bg-gradient-to-r from-purple-600 to-blue-600 text-white px-4 py-2 rounded-full text-sm font-semibold">
-                Interactive Demo
-              </div>
-            </motion.div>
-
             {/* Main heading */}
-            <h1 className="text-5xl md:text-6xl lg:text-7xl font-bold text-gray-900 mb-6">
-              <span className="block">Welcome to</span>
-              <span className="block bg-gradient-to-r from-purple-600 to-blue-600 bg-clip-text text-transparent">
-                Care Commons
-              </span>
+            <h1 className="text-6xl md:text-7xl lg:text-8xl font-bold text-gray-900 mb-8">
+              Care Commons
             </h1>
 
-            <p className="text-xl md:text-2xl text-gray-600 mb-8 max-w-3xl mx-auto">
-              Community-owned care coordination software built for{' '}
-              <span className="font-semibold text-gray-900">home healthcare agencies</span>
+            <p className="text-2xl text-gray-600 mb-12 max-w-2xl mx-auto">
+              Care coordination for home healthcare
             </p>
 
-            {/* CTA Buttons */}
-            <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-12">
-              <button
-                onClick={onStartTour}
-                className="group px-8 py-4 bg-gradient-to-r from-purple-600 to-blue-600 text-white rounded-lg font-semibold text-lg shadow-lg hover:shadow-xl transform hover:scale-105 transition-all duration-200 flex items-center gap-2"
-              >
-                Start Interactive Tour
-                <ArrowRight className="h-5 w-5 group-hover:translate-x-1 transition-transform" />
-              </button>
-              <a
-                href="https://github.com/neighborhood-lab/care-commons"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="px-8 py-4 bg-white text-gray-900 rounded-lg font-semibold text-lg border-2 border-gray-300 hover:border-gray-400 transition-colors"
-              >
-                View on GitHub
-              </a>
-            </div>
-
-            {/* Stats */}
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6 max-w-4xl mx-auto">
-              <StatCard
-                value="70%"
-                label="Reduction in EVV violations"
-                icon={<Shield className="h-6 w-6" />}
-                delay={0.3}
-              />
-              <StatCard
-                value="100+"
-                label="Daily visits managed"
-                icon={<Users className="h-6 w-6" />}
-                delay={0.4}
-              />
-              <StatCard
-                value="24/7"
-                label="Offline-capable mobile app"
-                icon={<Zap className="h-6 w-6" />}
-                delay={0.5}
-              />
-            </div>
+            {/* Single CTA Button */}
+            <button
+              onClick={onStartTour}
+              className="px-8 py-4 bg-gray-900 text-white rounded-lg font-medium text-lg hover:bg-gray-800 transition-colors"
+            >
+              Start
+            </button>
           </motion.div>
-        </div>
-      </div>
-
-      {/* Value Propositions */}
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-          <FeatureCard
-            icon={<Shield className="h-8 w-8" />}
-            title="EVV Compliance Made Easy"
-            description="Automatic GPS verification, geofencing, and six-element capture for seamless state compliance"
-            color="purple"
-          />
-          <FeatureCard
-            icon={<Globe className="h-8 w-8" />}
-            title="Multi-State Support"
-            description="Pre-configured rules for Texas, Florida, and 48 other states with automatic aggregator submission"
-            color="blue"
-          />
-          <FeatureCard
-            icon={<Zap className="h-8 w-8" />}
-            title="Works Offline"
-            description="Caregivers can work in dead zones and sync automatically when connection is restored"
-            color="green"
-          />
-        </div>
-      </div>
-
-      {/* Choose Your Journey */}
-      <div className="bg-white py-16">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <motion.div
-            initial={{ opacity: 0 }}
-            whileInView={{ opacity: 1 }}
-            viewport={{ once: true }}
-            transition={{ duration: 0.6 }}
-            className="text-center mb-12"
-          >
-            <h2 className="text-4xl font-bold text-gray-900 mb-4">
-              Choose Your Journey
-            </h2>
-            <p className="text-xl text-gray-600">
-              Explore the platform from different perspectives
-            </p>
-          </motion.div>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-            {personas.map((persona, index) => (
-              <PersonaCard
-                key={persona.id}
-                persona={persona}
-                onClick={() => onSelectRole(persona.id)}
-                delay={index * 0.1}
-              />
-            ))}
-          </div>
-        </div>
-      </div>
-
-      {/* Final CTA */}
-      <div className="bg-gradient-to-r from-purple-600 to-blue-600 py-16">
-        <div className="max-w-4xl mx-auto text-center px-4">
-          <h2 className="text-3xl md:text-4xl font-bold text-white mb-6">
-            Ready to Experience Care Commons?
-          </h2>
-          <p className="text-xl text-purple-100 mb-8">
-            Start exploring the platform with our interactive demo
-          </p>
-          <button
-            onClick={onStartTour}
-            className="px-8 py-4 bg-white text-purple-600 rounded-lg font-semibold text-lg shadow-lg hover:shadow-xl transform hover:scale-105 transition-all duration-200"
-          >
-            Begin Your Journey
-          </button>
         </div>
       </div>
     </div>
   );
 };
-
-// Supporting Components
-
-interface StatCardProps {
-  value: string;
-  label: string;
-  icon: React.ReactNode;
-  delay: number;
-}
-
-const StatCard: React.FC<StatCardProps> = ({ value, label, icon, delay }) => (
-  <motion.div
-    initial={{ opacity: 0, y: 20 }}
-    animate={{ opacity: 1, y: 0 }}
-    transition={{ delay, duration: 0.5 }}
-    className="bg-white rounded-lg shadow-md p-6 text-center"
-  >
-    <div className="inline-flex items-center justify-center w-12 h-12 bg-gradient-to-r from-purple-100 to-blue-100 rounded-full mb-4">
-      <div className="text-purple-600">{icon}</div>
-    </div>
-    <div className="text-3xl font-bold text-gray-900 mb-2">{value}</div>
-    <div className="text-sm text-gray-600">{label}</div>
-  </motion.div>
-);
-
-interface FeatureCardProps {
-  icon: React.ReactNode;
-  title: string;
-  description: string;
-  color: string;
-}
-
-const FeatureCard: React.FC<FeatureCardProps> = ({ icon, title, description, color }) => (
-  <motion.div
-    whileHover={{ scale: 1.05 }}
-    className="bg-white rounded-xl shadow-lg p-6 hover:shadow-xl transition-all duration-300"
-  >
-    <div className={`inline-flex items-center justify-center w-16 h-16 bg-${color}-100 rounded-lg mb-4`}>
-      <div className={`text-${color}-600`}>{icon}</div>
-    </div>
-    <h3 className="text-xl font-bold text-gray-900 mb-2">{title}</h3>
-    <p className="text-gray-600">{description}</p>
-  </motion.div>
-);
-
-interface PersonaCardProps {
-  persona: any;
-  onClick: () => void;
-  delay: number;
-}
-
-const PersonaCard: React.FC<PersonaCardProps> = ({ persona, onClick, delay }) => (
-  <motion.button
-    initial={{ opacity: 0, y: 20 }}
-    whileInView={{ opacity: 1, y: 0 }}
-    viewport={{ once: true }}
-    transition={{ delay, duration: 0.5 }}
-    whileHover={{ scale: 1.05, y: -5 }}
-    onClick={onClick}
-    className="bg-white rounded-xl shadow-md p-6 text-left hover:shadow-xl transition-all duration-300 border-2 border-transparent hover:border-purple-500"
-  >
-    <div className={`w-16 h-16 rounded-full bg-${persona.color}-100 flex items-center justify-center mb-4`}>
-      <span className="text-3xl">
-        {persona.id === 'admin' && '👨‍💼'}
-        {persona.id === 'coordinator' && '👩‍⚕️'}
-        {persona.id === 'caregiver' && '👩‍🔬'}
-        {persona.id === 'patient' && '👵'}
-      </span>
-    </div>
-    <h3 className="text-xl font-bold text-gray-900 mb-2">{persona.name}</h3>
-    <p className="text-sm text-gray-600 mb-3">{persona.title}</p>
-    <div className={`inline-block px-3 py-1 bg-${persona.color}-100 text-${persona.color}-700 rounded-full text-xs font-semibold mb-3`}>
-      {persona.estimatedTime} min experience
-    </div>
-    <p className="text-sm text-gray-500 mb-3">{persona.missionTitle}</p>
-    <div className="flex items-center text-purple-600 font-medium text-sm">
-      Start exploring
-      <ArrowRight className="h-4 w-4 ml-1" />
-    </div>
-  </motion.button>
-);
-
-// Add animations to global CSS or Tailwind config
-const style = document.createElement('style');
-style.textContent = `
-  @keyframes blob {
-    0%, 100% { transform: translate(0, 0) scale(1); }
-    25% { transform: translate(20px, -50px) scale(1.1); }
-    50% { transform: translate(-20px, 20px) scale(0.9); }
-    75% { transform: translate(50px, 50px) scale(1.05); }
-  }
-
-  .animate-blob {
-    animation: blob 7s infinite;
-  }
-
-  .animation-delay-2000 {
-    animation-delay: 2s;
-  }
-`;
-document.head.appendChild(style);

--- a/packages/web/src/showcase/pages/ScenarioLibraryPage.tsx
+++ b/packages/web/src/showcase/pages/ScenarioLibraryPage.tsx
@@ -4,114 +4,38 @@
  * Browse and start narrative-driven scenarios
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 import { motion } from 'framer-motion';
-import { Play, Clock, User, Award, ArrowRight } from 'lucide-react';
-import { allScenarios, scenarioCategories, useScenario } from '../scenarios';
+import { allScenarios, useScenario } from '../scenarios';
 import { Scenario, PersonaRole } from '../types';
 
 export const ScenarioLibraryPage: React.FC = () => {
-  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
-  const [selectedDifficulty, setSelectedDifficulty] = useState<string | null>(null);
   const { startScenario } = useScenario();
-
-  const filteredScenarios = allScenarios.filter(scenario => {
-    if (selectedCategory && scenario.category !== selectedCategory) return false;
-    if (selectedDifficulty && scenario.difficulty !== selectedDifficulty) return false;
-    return true;
-  });
 
   const handleStartScenario = (scenario: Scenario) => {
     startScenario(scenario);
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-purple-50 via-blue-50 to-white">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+    <div className="min-h-screen bg-white">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
         {/* Header */}
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          className="text-center mb-12"
+          className="mb-12"
         >
-          <h1 className="text-4xl md:text-5xl font-bold text-gray-900 mb-4">
-            Scenario Library
+          <h1 className="text-5xl font-bold text-gray-900 mb-4">
+            Scenarios
           </h1>
-          <p className="text-xl text-gray-600 max-w-3xl mx-auto">
-            Experience realistic workflows through interactive, narrative-driven scenarios
+          <p className="text-xl text-gray-600">
+            Explore workflows
           </p>
         </motion.div>
 
-        {/* Filters */}
-        <div className="mb-8 space-y-4">
-          {/* Category Filter */}
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              Filter by Category
-            </label>
-            <div className="flex flex-wrap gap-2">
-              <button
-                onClick={() => setSelectedCategory(null)}
-                className={`px-4 py-2 rounded-lg font-medium transition-colors ${
-                  selectedCategory === null
-                    ? 'bg-purple-600 text-white'
-                    : 'bg-white text-gray-700 border border-gray-300 hover:border-purple-500'
-                }`}
-              >
-                All Categories
-              </button>
-              {scenarioCategories.map(category => (
-                <button
-                  key={category.id}
-                  onClick={() => setSelectedCategory(category.id)}
-                  className={`px-4 py-2 rounded-lg font-medium transition-colors ${
-                    selectedCategory === category.id
-                      ? 'bg-purple-600 text-white'
-                      : 'bg-white text-gray-700 border border-gray-300 hover:border-purple-500'
-                  }`}
-                >
-                  {category.icon} {category.name}
-                </button>
-              ))}
-            </div>
-          </div>
-
-          {/* Difficulty Filter */}
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              Filter by Difficulty
-            </label>
-            <div className="flex flex-wrap gap-2">
-              <button
-                onClick={() => setSelectedDifficulty(null)}
-                className={`px-4 py-2 rounded-lg font-medium transition-colors ${
-                  selectedDifficulty === null
-                    ? 'bg-blue-600 text-white'
-                    : 'bg-white text-gray-700 border border-gray-300 hover:border-blue-500'
-                }`}
-              >
-                All Levels
-              </button>
-              {['beginner', 'intermediate', 'advanced'].map(diff => (
-                <button
-                  key={diff}
-                  onClick={() => setSelectedDifficulty(diff)}
-                  className={`px-4 py-2 rounded-lg font-medium transition-colors capitalize ${
-                    selectedDifficulty === diff
-                      ? 'bg-blue-600 text-white'
-                      : 'bg-white text-gray-700 border border-gray-300 hover:border-blue-500'
-                  }`}
-                >
-                  {diff}
-                </button>
-              ))}
-            </div>
-          </div>
-        </div>
-
         {/* Scenarios Grid */}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {filteredScenarios.map((scenario, index) => (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {allScenarios.map((scenario, index) => (
             <ScenarioCard
               key={scenario.id}
               scenario={scenario}
@@ -120,24 +44,6 @@ export const ScenarioLibraryPage: React.FC = () => {
             />
           ))}
         </div>
-
-        {/* Empty State */}
-        {filteredScenarios.length === 0 && (
-          <div className="text-center py-12">
-            <p className="text-gray-600 text-lg">
-              No scenarios found matching your filters
-            </p>
-            <button
-              onClick={() => {
-                setSelectedCategory(null);
-                setSelectedDifficulty(null);
-              }}
-              className="mt-4 px-6 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors"
-            >
-              Clear Filters
-            </button>
-          </div>
-        )}
       </div>
     </div>
   );
@@ -152,14 +58,6 @@ interface ScenarioCardProps {
 }
 
 const ScenarioCard: React.FC<ScenarioCardProps> = ({ scenario, onStart, delay }) => {
-  const category = scenarioCategories.find(c => c.id === scenario.category);
-
-  const difficultyColors = {
-    beginner: 'bg-green-100 text-green-700',
-    intermediate: 'bg-yellow-100 text-yellow-700',
-    advanced: 'bg-red-100 text-red-700',
-  };
-
   const roleLabels: Record<PersonaRole, string> = {
     admin: 'Administrator',
     coordinator: 'Care Coordinator',
@@ -172,62 +70,18 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({ scenario, onStart, delay })
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ delay, duration: 0.5 }}
-      whileHover={{ scale: 1.02, y: -5 }}
-      className="bg-white rounded-xl shadow-lg overflow-hidden hover:shadow-xl transition-all duration-300 border-2 border-transparent hover:border-purple-500"
+      className="bg-white rounded-lg border-2 border-gray-200 hover:border-gray-900 transition-all p-6"
     >
-      {/* Header */}
-      <div className={`bg-gradient-to-r from-${category?.color}-500 to-${category?.color}-600 p-4`}>
-        <div className="flex items-center justify-between mb-2">
-          <span className="text-2xl">{category?.icon}</span>
-          <span className={`px-2 py-1 rounded-full text-xs font-semibold ${difficultyColors[scenario.difficulty]}`}>
-            {scenario.difficulty}
-          </span>
-        </div>
-        <h3 className="text-xl font-bold text-white">{scenario.title}</h3>
-      </div>
+      <h3 className="text-xl font-bold text-gray-900 mb-2">{scenario.title}</h3>
+      <p className="text-gray-600 mb-4">{roleLabels[scenario.role]}</p>
 
-      {/* Body */}
-      <div className="p-6">
-        <p className="text-gray-600 mb-4 line-clamp-2">{scenario.description}</p>
-
-        {/* Meta Info */}
-        <div className="space-y-2 mb-4">
-          <div className="flex items-center gap-2 text-sm text-gray-600">
-            <Clock className="h-4 w-4" />
-            <span>{scenario.estimatedTime} minutes</span>
-          </div>
-          <div className="flex items-center gap-2 text-sm text-gray-600">
-            <User className="h-4 w-4" />
-            <span>{roleLabels[scenario.role]}</span>
-          </div>
-          <div className="flex items-center gap-2 text-sm text-gray-600">
-            <Award className="h-4 w-4" />
-            <span>{scenario.steps.length} steps</span>
-          </div>
-        </div>
-
-        {/* Tags */}
-        <div className="flex flex-wrap gap-2 mb-4">
-          {scenario.tags.slice(0, 3).map(tag => (
-            <span
-              key={tag}
-              className="px-2 py-1 bg-gray-100 text-gray-700 rounded-full text-xs"
-            >
-              {tag}
-            </span>
-          ))}
-        </div>
-
-        {/* Start Button */}
-        <button
-          onClick={onStart}
-          className="w-full flex items-center justify-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 text-white rounded-lg font-semibold hover:from-purple-700 hover:to-blue-700 transition-all duration-200 group"
-        >
-          <Play className="h-5 w-5" />
-          <span>Start Scenario</span>
-          <ArrowRight className="h-5 w-5 group-hover:translate-x-1 transition-transform" />
-        </button>
-      </div>
+      {/* Start Button */}
+      <button
+        onClick={onStart}
+        className="w-full px-6 py-3 bg-gray-900 text-white rounded-lg font-medium hover:bg-gray-800 transition-colors"
+      >
+        Start
+      </button>
     </motion.div>
   );
 };


### PR DESCRIPTION
Simplified the showcase UI to be more intentional and less overwhelming:

- Landing page: removed stat cards, feature cards, and persona cards. Now shows only the main heading and single CTA button
- Role selector: removed search, "Surprise Me" button, detailed feature lists, and metadata. Shows only basic role info
- Welcome modal: reduced from 3 steps to 1 simple screen with minimal text
- Scenario page: removed category and difficulty filters. Shows all scenarios in simplified cards with just title, role, and start button
- Showcase controls: simplified info modal and removed verbose feature lists. Reduced banner text
- Color palette: replaced purple/blue gradients with consistent gray/black throughout for a more purposeful, stripped-down aesthetic

Changes allow users to discover features gradually rather than being presented with all information at once.