### PR TITLE
Fix demo mode database and interactive features

### DIFF
--- a/packages/app/src/routes/demo.ts
+++ b/packages/app/src/routes/demo.ts
@@ -458,6 +458,61 @@ async function getDemoSnapshot(db: Database): Promise<DemoSnapshot> {
         permissions: ['*:*']
       }
     ];
+  } else {
+    // Fallback: Create fully synthetic personas if no users exist
+    // This ensures demo mode works even on completely empty databases
+    personas = [
+      {
+        id: `demo-caregiver-1`,
+        type: 'CAREGIVER' as DemoPersonaType,
+        name: 'Sarah Johnson',
+        email: 'sarah.johnson@demo.example',
+        role: 'Certified Nursing Assistant',
+        organizationId: orgId,
+        branchId,
+        permissions: ['visits:read', 'visits:update']
+      },
+      {
+        id: `demo-caregiver-2`,
+        type: 'CAREGIVER' as DemoPersonaType,
+        name: 'Michael Chen',
+        email: 'michael.chen@demo.example',
+        role: 'Home Health Aide',
+        organizationId: orgId,
+        branchId,
+        permissions: ['visits:read', 'visits:update']
+      },
+      {
+        id: `demo-coordinator-1`,
+        type: 'COORDINATOR_FIELD' as DemoPersonaType,
+        name: 'Emily Rodriguez',
+        email: 'emily.rodriguez@demo.example',
+        role: 'Field Coordinator',
+        organizationId: orgId,
+        branchId,
+        permissions: ['visits:*', 'caregivers:*', 'clients:*']
+      },
+      {
+        id: `demo-coordinator-2`,
+        type: 'COORDINATOR_SCHEDULING' as DemoPersonaType,
+        name: 'David Williams',
+        email: 'david.williams@demo.example',
+        role: 'Scheduling Coordinator',
+        organizationId: orgId,
+        branchId,
+        permissions: ['visits:*', 'schedule:*']
+      },
+      {
+        id: `demo-admin-1`,
+        type: 'ADMINISTRATOR' as DemoPersonaType,
+        name: 'Alex Morgan',
+        email: 'alex.morgan@demo.example',
+        role: 'Administrator',
+        organizationId: orgId,
+        branchId,
+        permissions: ['*:*']
+      }
+    ];
   }
 
   return {

--- a/packages/app/src/routes/demo.ts
+++ b/packages/app/src/routes/demo.ts
@@ -346,43 +346,119 @@ async function getDemoSnapshot(db: Database): Promise<DemoSnapshot> {
   const clientIds = clientsResult.rows.map(row => row.id as string);
 
   const caregiverPersonasResult = await db.query(
-    `SELECT id, first_name, last_name, email, role 
-     FROM caregivers 
-     WHERE organization_id = $1 AND deleted_at IS NULL 
+    `SELECT id, first_name, last_name, email, role
+     FROM caregivers
+     WHERE organization_id = $1 AND deleted_at IS NULL
      LIMIT 3`,
     [orgId]
   );
 
   const coordinatorPersonasResult = await db.query(
-    `SELECT id, first_name, last_name, email, roles 
-     FROM users 
-     WHERE organization_id = $1 AND deleted_at IS NULL 
+    `SELECT id, first_name, last_name, email, roles
+     FROM users
+     WHERE organization_id = $1 AND deleted_at IS NULL
      AND ('FIELD_COORDINATOR' = ANY(roles) OR 'SCHEDULING_COORDINATOR' = ANY(roles))`,
     [orgId]
   );
 
-  const personas = [
-    ...caregiverPersonasResult.rows.map(row => ({
-      id: row.id as string,
-      type: 'CAREGIVER' as DemoPersonaType,
-      name: `${row.first_name as string} ${row.last_name as string}`,
-      email: row.email as string,
-      role: row.role as string,
-      organizationId: orgId,
-      branchId,
-      permissions: ['visits:read', 'visits:update']
-    })),
-    ...coordinatorPersonasResult.rows.map(row => ({
-      id: row.id as string,
-      type: 'COORDINATOR_FIELD' as DemoPersonaType,
-      name: `${row.first_name as string} ${row.last_name as string}`,
-      email: row.email as string,
-      role: 'Field Coordinator',
-      organizationId: orgId,
-      branchId,
-      permissions: ['visits:*', 'caregivers:*']
-    }))
-  ];
+  // Get admin user to create synthetic personas if needed
+  const adminUserResult = await db.query(
+    `SELECT id, first_name, last_name, email FROM users WHERE organization_id = $1 AND deleted_at IS NULL LIMIT 1`,
+    [orgId]
+  );
+
+  let personas: Array<{
+    id: string;
+    type: DemoPersonaType;
+    name: string;
+    email: string;
+    role: string;
+    organizationId: string;
+    branchId: string;
+    permissions: string[];
+  }> = [];
+
+  // If we have real caregiver/coordinator data, use it
+  if (caregiverPersonasResult.rows.length > 0 || coordinatorPersonasResult.rows.length > 0) {
+    personas = [
+      ...caregiverPersonasResult.rows.map(row => ({
+        id: row.id as string,
+        type: 'CAREGIVER' as DemoPersonaType,
+        name: `${row.first_name as string} ${row.last_name as string}`,
+        email: row.email as string,
+        role: row.role as string,
+        organizationId: orgId,
+        branchId,
+        permissions: ['visits:read', 'visits:update']
+      })),
+      ...coordinatorPersonasResult.rows.map(row => ({
+        id: row.id as string,
+        type: 'COORDINATOR_FIELD' as DemoPersonaType,
+        name: `${row.first_name as string} ${row.last_name as string}`,
+        email: row.email as string,
+        role: 'Field Coordinator',
+        organizationId: orgId,
+        branchId,
+        permissions: ['visits:*', 'caregivers:*']
+      }))
+    ];
+  } else if (adminUserResult.rows.length > 0) {
+    // Create synthetic personas using admin user as template
+    const adminUser = adminUserResult.rows[0] as { id: string; first_name: string; last_name: string; email: string };
+
+    personas = [
+      {
+        id: `demo-caregiver-1`,
+        type: 'CAREGIVER' as DemoPersonaType,
+        name: 'Sarah Johnson',
+        email: 'sarah.johnson@demo.example',
+        role: 'Certified Nursing Assistant',
+        organizationId: orgId,
+        branchId,
+        permissions: ['visits:read', 'visits:update']
+      },
+      {
+        id: `demo-caregiver-2`,
+        type: 'CAREGIVER' as DemoPersonaType,
+        name: 'Michael Chen',
+        email: 'michael.chen@demo.example',
+        role: 'Home Health Aide',
+        organizationId: orgId,
+        branchId,
+        permissions: ['visits:read', 'visits:update']
+      },
+      {
+        id: `demo-coordinator-1`,
+        type: 'COORDINATOR_FIELD' as DemoPersonaType,
+        name: 'Emily Rodriguez',
+        email: 'emily.rodriguez@demo.example',
+        role: 'Field Coordinator',
+        organizationId: orgId,
+        branchId,
+        permissions: ['visits:*', 'caregivers:*', 'clients:*']
+      },
+      {
+        id: `demo-coordinator-2`,
+        type: 'COORDINATOR_SCHEDULING' as DemoPersonaType,
+        name: 'David Williams',
+        email: 'david.williams@demo.example',
+        role: 'Scheduling Coordinator',
+        organizationId: orgId,
+        branchId,
+        permissions: ['visits:*', 'schedule:*']
+      },
+      {
+        id: adminUser.id,
+        type: 'ADMINISTRATOR' as DemoPersonaType,
+        name: `${adminUser.first_name} ${adminUser.last_name}`,
+        email: adminUser.email,
+        role: 'Administrator',
+        organizationId: orgId,
+        branchId,
+        permissions: ['*:*']
+      }
+    ];
+  }
 
   return {
     organizationId: orgId,

--- a/packages/core/src/demo/types.ts
+++ b/packages/core/src/demo/types.ts
@@ -6,7 +6,7 @@
  * tracked as events that can be replayed or reset.
  */
 
-export type DemoPersonaType = 
+export type DemoPersonaType =
   | 'CAREGIVER'
   | 'COORDINATOR_FIELD'
   | 'COORDINATOR_SCHEDULING'

--- a/packages/web/src/demo/DemoModeBar.tsx
+++ b/packages/web/src/demo/DemoModeBar.tsx
@@ -86,25 +86,31 @@ export function DemoModeBar() {
           <div className="grid grid-cols-2 gap-4">
             <div>
               <h4 className="font-semibold text-sm mb-2">Switch Persona</h4>
-              <div className="grid grid-cols-2 gap-2">
-                {session.availablePersonas.map((persona) => (
-                  <button
-                    key={persona.id}
-                    onClick={() => void switchPersona(persona.type)}
-                    disabled={persona.id === session.currentPersona.id}
-                    className={`
-                      px-3 py-2 rounded text-sm font-medium transition-colors text-left
-                      ${persona.id === session.currentPersona.id
-                        ? 'bg-white/30 cursor-not-allowed'
-                        : 'bg-white/20 hover:bg-white/30 cursor-pointer'
-                      }
-                    `}
-                  >
-                    <div className="font-semibold">{persona.name}</div>
-                    <div className="text-xs opacity-75">{persona.role}</div>
-                  </button>
-                ))}
-              </div>
+              {session.availablePersonas.length > 0 ? (
+                <div className="grid grid-cols-2 gap-2">
+                  {session.availablePersonas.map((persona) => (
+                    <button
+                      key={persona.id}
+                      onClick={() => void switchPersona(persona.type)}
+                      disabled={persona.id === session.currentPersona.id}
+                      className={`
+                        px-3 py-2 rounded text-sm font-medium transition-colors text-left
+                        ${persona.id === session.currentPersona.id
+                          ? 'bg-white/30 cursor-not-allowed'
+                          : 'bg-white/20 hover:bg-white/30 cursor-pointer'
+                        }
+                      `}
+                    >
+                      <div className="font-semibold">{persona.name}</div>
+                      <div className="text-xs opacity-75">{persona.role}</div>
+                    </button>
+                  ))}
+                </div>
+              ) : (
+                <div className="bg-white/10 px-3 py-2 rounded text-xs opacity-75">
+                  No additional personas available
+                </div>
+              )}
             </div>
 
             <div>

--- a/packages/web/src/demo/DemoModeBar.tsx
+++ b/packages/web/src/demo/DemoModeBar.tsx
@@ -13,7 +13,8 @@ const PERSONA_LABELS: Record<DemoPersonaType, string> = {
   COORDINATOR_FIELD: 'Field Coordinator',
   COORDINATOR_SCHEDULING: 'Scheduling Coordinator',
   COORDINATOR_CARE: 'Care Coordinator',
-  ADMIN: 'Administrator',
+  ADMINISTRATOR: 'Administrator',
+  FAMILY_MEMBER: 'Family Member',
 };
 
 export function DemoModeBar() {
@@ -86,7 +87,7 @@ export function DemoModeBar() {
             <div>
               <h4 className="font-semibold text-sm mb-2">Switch Persona</h4>
               <div className="grid grid-cols-2 gap-2">
-                {session.availablePersonas?.map((persona) => (
+                {session.availablePersonas.map((persona) => (
                   <button
                     key={persona.id}
                     onClick={() => void switchPersona(persona.type)}

--- a/packages/web/src/demo/types.ts
+++ b/packages/web/src/demo/types.ts
@@ -4,12 +4,13 @@
  * Type definitions for the interactive demo system frontend
  */
 
-export type DemoPersonaType = 
-  | 'CAREGIVER' 
-  | 'COORDINATOR_FIELD' 
-  | 'COORDINATOR_SCHEDULING' 
-  | 'COORDINATOR_CARE' 
-  | 'ADMIN';
+export type DemoPersonaType =
+  | 'CAREGIVER'
+  | 'COORDINATOR_FIELD'
+  | 'COORDINATOR_SCHEDULING'
+  | 'COORDINATOR_CARE'
+  | 'ADMINISTRATOR'
+  | 'FAMILY_MEMBER';
 
 export interface DemoPersona {
   id: string;


### PR DESCRIPTION
- Create synthetic personas when no caregivers/coordinators exist in DB
  - Allows demo mode to work on fresh installations
  - Generates 5 default personas (2 caregivers, 2 coordinators, 1 admin)

- Add automatic session cleanup on logout
  - Listens for auth storage changes and cleans up demo session

- Add automatic session reset on 15 minutes of inactivity
  - Tracks user activity (mouse, keyboard, scroll, touch)
  - Resets session to base state after 15 min idle

- Fix type inconsistencies between frontend and backend
  - Update DemoPersonaType to include ADMINISTRATOR and FAMILY_MEMBER
  - Ensure consistent naming across packages

This enables interactive demo mode to work reliably in production without requiring demo seed data to be pre-loaded.