### PR TITLE
fix: critical permission check bug in schedule-service

### DIFF
--- a/verticals/scheduling-visits/src/service/schedule-service.ts
+++ b/verticals/scheduling-visits/src/service/schedule-service.ts
@@ -704,7 +704,9 @@ export class ScheduleService {
   }
 
   private checkPermission(context: UserContext, permission: string): void {
-    if (!(context.permissions?.includes(permission) && context.roles?.includes('SUPER_ADMIN'))) {
+    // CRITICAL FIX: Changed && to || - previous logic would require BOTH permission AND SUPER_ADMIN role
+    // Correct logic: User needs EITHER the specific permission OR SUPER_ADMIN role
+    if (!(context.permissions?.includes(permission) || context.roles?.includes('SUPER_ADMIN'))) {
       throw new PermissionError(`Missing required permission: ${permission}`, {
         userId: context.userId,
         permission,


### PR DESCRIPTION
## 🚨 CRITICAL BUG FIX

Corrected permission validation logic that was using AND instead of OR, causing legitimate access to be denied.

## Bug Details

**Location:** `verticals/scheduling-visits/src/service/schedule-service.ts:707`

### Previous (INCORRECT):
```typescript
if (!(context.permissions?.includes(permission) && context.roles?.includes('SUPER_ADMIN')))
```

This logic required users to have **BOTH** the specific permission **AND** the SUPER_ADMIN role.

### Fixed (CORRECT):
```typescript
if (!(context.permissions?.includes(permission) || context.roles?.includes('SUPER_ADMIN')))
```

Users should be granted access if they have **EITHER**:
- The specific permission, **OR**
- The SUPER_ADMIN role

## Impact

This bug would have prevented:
- ❌ Regular users with correct permissions from accessing resources
- ✅ Only SUPER_ADMIN users with the specific permission could access
- 🚨 Likely causing widespread access denial in scheduling/visits vertical

## Root Cause

Logic error in custom permission checking method. This highlights the need for standardized permission utilities across the codebase (follow-up work planned).

## Testing

- ✅ Verified logic correction
- ✅ Added clarifying comment to prevent regression