### PR TITLE
Add new option to navigation bar

### DIFF
--- a/packages/web/src/app/components/Sidebar.tsx
+++ b/packages/web/src/app/components/Sidebar.tsx
@@ -8,6 +8,7 @@ import {
   CheckSquare,
   FileText,
   DollarSign,
+  Wallet,
   Settings,
   LogOut,
   X,
@@ -78,6 +79,12 @@ const navItems: NavItem[] = [
     path: '/billing',
     icon: <DollarSign className="h-5 w-5" />,
     permission: 'billing:read',
+  },
+  {
+    label: 'Payroll',
+    path: '/payroll',
+    icon: <Wallet className="h-5 w-5" />,
+    permission: 'payroll:read',
   },
   {
     label: 'Admin',


### PR DESCRIPTION
Add a new "Payroll" menu item to the main navigation sidebar, positioned between Billing and Admin. This provides direct access to the existing payroll management functionality at /payroll.

Changes:
- Import Wallet icon from lucide-react
- Add Payroll nav item with payroll:read permission
- Route to /payroll path

This improves navigation by making the payroll management feature more discoverable to users with appropriate permissions.