### PR TITLE
Add US State Selection Feature

### DIFF
--- a/packages/web/src/core/services/organization-api.ts
+++ b/packages/web/src/core/services/organization-api.ts
@@ -101,12 +101,9 @@ export interface ApiResponse<T> {
 
 /**
  * US States list for state selector
- * Currently configured for TX and FL, designed to scale to all 50 states
+ * Complete list of all 50 US states
  */
 export const US_STATES: USStateCode[] = [
-  { code: 'TX', name: 'Texas' },
-  { code: 'FL', name: 'Florida' },
-  // Additional states can be added as the platform scales
   { code: 'AL', name: 'Alabama' },
   { code: 'AK', name: 'Alaska' },
   { code: 'AZ', name: 'Arizona' },
@@ -115,8 +112,48 @@ export const US_STATES: USStateCode[] = [
   { code: 'CO', name: 'Colorado' },
   { code: 'CT', name: 'Connecticut' },
   { code: 'DE', name: 'Delaware' },
+  { code: 'FL', name: 'Florida' },
   { code: 'GA', name: 'Georgia' },
-  // ... (remaining states can be added as needed)
+  { code: 'HI', name: 'Hawaii' },
+  { code: 'ID', name: 'Idaho' },
+  { code: 'IL', name: 'Illinois' },
+  { code: 'IN', name: 'Indiana' },
+  { code: 'IA', name: 'Iowa' },
+  { code: 'KS', name: 'Kansas' },
+  { code: 'KY', name: 'Kentucky' },
+  { code: 'LA', name: 'Louisiana' },
+  { code: 'ME', name: 'Maine' },
+  { code: 'MD', name: 'Maryland' },
+  { code: 'MA', name: 'Massachusetts' },
+  { code: 'MI', name: 'Michigan' },
+  { code: 'MN', name: 'Minnesota' },
+  { code: 'MS', name: 'Mississippi' },
+  { code: 'MO', name: 'Missouri' },
+  { code: 'MT', name: 'Montana' },
+  { code: 'NE', name: 'Nebraska' },
+  { code: 'NV', name: 'Nevada' },
+  { code: 'NH', name: 'New Hampshire' },
+  { code: 'NJ', name: 'New Jersey' },
+  { code: 'NM', name: 'New Mexico' },
+  { code: 'NY', name: 'New York' },
+  { code: 'NC', name: 'North Carolina' },
+  { code: 'ND', name: 'North Dakota' },
+  { code: 'OH', name: 'Ohio' },
+  { code: 'OK', name: 'Oklahoma' },
+  { code: 'OR', name: 'Oregon' },
+  { code: 'PA', name: 'Pennsylvania' },
+  { code: 'RI', name: 'Rhode Island' },
+  { code: 'SC', name: 'South Carolina' },
+  { code: 'SD', name: 'South Dakota' },
+  { code: 'TN', name: 'Tennessee' },
+  { code: 'TX', name: 'Texas' },
+  { code: 'UT', name: 'Utah' },
+  { code: 'VT', name: 'Vermont' },
+  { code: 'VA', name: 'Virginia' },
+  { code: 'WA', name: 'Washington' },
+  { code: 'WV', name: 'West Virginia' },
+  { code: 'WI', name: 'Wisconsin' },
+  { code: 'WY', name: 'Wyoming' },
 ];
 
 export class OrganizationApi {


### PR DESCRIPTION
Expanded the US_STATES constant from 11 states to all 50 US states in alphabetical order. This enables full US state selection in the organization registration form and any other forms that use the US_STATES constant.

Changes:
- Updated US_STATES array in organization-api.ts to include all 50 states
- Maintained alphabetical ordering for easy navigation
- States are now available for use in OrganizationRegistrationForm and any future forms requiring state selection