### PR TITLE
Add operation to navigation bar

### DIFF
--- a/packages/web/src/app/components/Header.tsx
+++ b/packages/web/src/app/components/Header.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import { Menu, Bell, User } from 'lucide-react';
+import { Menu, Bell, User, Plus, UserPlus, Users, ClipboardList, Calendar } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 import { useAuth } from '@/core/hooks';
-import { Button } from '@/core/components';
+import { usePermissions } from '@/core/hooks/permissions';
+import { Button, Dropdown, DropdownItem } from '@/core/components';
 
 export interface HeaderProps {
   onMenuClick: () => void;
@@ -9,6 +11,35 @@ export interface HeaderProps {
 
 export const Header: React.FC<HeaderProps> = ({ onMenuClick }) => {
   const { user } = useAuth();
+  const navigate = useNavigate();
+  const { can } = usePermissions();
+
+  const quickActions: DropdownItem[] = [
+    {
+      label: 'Create Client',
+      icon: <UserPlus className="h-5 w-5" />,
+      onClick: () => navigate('/clients/new'),
+      hidden: !can('clients:create')
+    },
+    {
+      label: 'Create Caregiver',
+      icon: <Users className="h-5 w-5" />,
+      onClick: () => navigate('/caregivers/new'),
+      hidden: !can('caregivers:create')
+    },
+    {
+      label: 'Create Care Plan',
+      icon: <ClipboardList className="h-5 w-5" />,
+      onClick: () => navigate('/care-plans/new'),
+      hidden: !can('care_plans:create')
+    },
+    {
+      label: 'Schedule Visit',
+      icon: <Calendar className="h-5 w-5" />,
+      onClick: () => navigate('/scheduling'),
+      hidden: !can('visits:create')
+    }
+  ];
 
   return (
     <header className="bg-white border-b border-gray-200 sticky top-0 z-40">
@@ -26,6 +57,15 @@ export const Header: React.FC<HeaderProps> = ({ onMenuClick }) => {
         </div>
 
         <div className="flex items-center gap-4">
+          <Dropdown
+            trigger={
+              <Button variant="primary" size="sm" className="gap-2">
+                <Plus className="h-5 w-5" />
+                <span className="hidden sm:inline">Quick Actions</span>
+              </Button>
+            }
+            items={quickActions}
+          />
           <Button variant="ghost" size="sm">
             <Bell className="h-5 w-5" />
           </Button>

--- a/packages/web/src/core/components/Dropdown.tsx
+++ b/packages/web/src/core/components/Dropdown.tsx
@@ -1,0 +1,96 @@
+import React, { useState, useRef, useEffect } from 'react';
+
+export interface DropdownItem {
+  label: string;
+  icon?: React.ReactNode;
+  onClick: () => void;
+  disabled?: boolean;
+  hidden?: boolean;
+}
+
+export interface DropdownProps {
+  trigger: React.ReactNode;
+  items: DropdownItem[];
+  align?: 'left' | 'right';
+}
+
+export const Dropdown: React.FC<DropdownProps> = ({
+  trigger,
+  items,
+  align = 'right'
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+      document.addEventListener('keydown', handleEscape);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [isOpen]);
+
+  const visibleItems = items.filter(item => !item.hidden);
+
+  if (visibleItems.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <div onClick={() => setIsOpen(!isOpen)}>
+        {trigger}
+      </div>
+
+      {isOpen && (
+        <div
+          className={`absolute mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-50 ${
+            align === 'right' ? 'right-0' : 'left-0'
+          }`}
+        >
+          <div className="py-1" role="menu">
+            {visibleItems.map((item, index) => (
+              <button
+                key={index}
+                onClick={() => {
+                  if (!item.disabled) {
+                    item.onClick();
+                    setIsOpen(false);
+                  }
+                }}
+                disabled={item.disabled}
+                className={`
+                  flex items-center gap-3 w-full text-left px-4 py-2 text-sm
+                  ${item.disabled
+                    ? 'text-gray-400 cursor-not-allowed'
+                    : 'text-gray-700 hover:bg-gray-100 hover:text-gray-900'
+                  }
+                `}
+                role="menuitem"
+              >
+                {item.icon && <span className="h-5 w-5">{item.icon}</span>}
+                {item.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/web/src/core/components/index.ts
+++ b/packages/web/src/core/components/index.ts
@@ -1,5 +1,6 @@
 export * from './Button';
 export * from './Card';
 export * from './Badge';
+export * from './Dropdown';
 export * from './forms';
 export * from './feedback';


### PR DESCRIPTION
Add a Quick Actions dropdown menu to the header that provides quick access to common operations. The dropdown includes permission-based filtering for:

- Create Client (clients:create)
- Create Caregiver (caregivers:create)
- Create Care Plan (care_plans:create)
- Schedule Visit (visits:create)

Implementation details:
- Created reusable Dropdown component with keyboard navigation and click-outside handling
- Added Quick Actions button with Plus icon to the header
- Integrated with existing permission system to show only allowed actions
- Responsive design - hides "Quick Actions" label on mobile
- Proper z-index handling for dropdown overlay

This improves user efficiency by providing quick access to frequently used operations without navigating through multiple pages.