### PR TITLE
Fix analytics-reporting lint script error

### DIFF
--- a/verticals/analytics-reporting/package.json
+++ b/verticals/analytics-reporting/package.json
@@ -32,12 +32,12 @@
     }
   },
   "scripts": {
-    "build": "echo '⚠️  analytics-reporting build skipped - see ARCHITECTURAL_ISSUES.md' && exit 0",
+    "build": "echo '⚠️  analytics-reporting build skipped - see ARCHITECTURAL_ISSUES.md' && true",
     "build:real": "tsc && tsc-alias -p tsconfig.json",
-    "test": "echo '⚠️  analytics-reporting tests skipped - see ARCHITECTURAL_ISSUES.md' && exit 0",
-    "test:coverage": "echo '⚠️  analytics-reporting tests skipped - see ARCHITECTURAL_ISSUES.md' && exit 0",
+    "test": "echo '⚠️  analytics-reporting tests skipped - see ARCHITECTURAL_ISSUES.md' && true",
+    "test:coverage": "echo '⚠️  analytics-reporting tests skipped - see ARCHITECTURAL_ISSUES.md' && true",
     "test:real": "vitest",
-    "lint": "echo '⚠️  analytics-reporting lint skipped - see ARCHITECTURAL_ISSUES.md' && exit 0",
+    "lint": "echo '⚠️  analytics-reporting lint skipped - see ARCHITECTURAL_ISSUES.md' && true",
     "lint:real": "eslint . --ext ts"
   },
   "dependencies": {


### PR DESCRIPTION
The lint script was using 'exit 0' which fails when npm passes additional arguments via '--'. When turbo runs 'npm run lint -- --fix', it becomes 'exit 0 --fix' which is invalid (exit doesn't accept arguments).

Changed all skip scripts (build, test, test:coverage, lint) to use 'true' instead of 'exit 0', which properly handles and ignores any extra arguments.

This fixes the check.sh script failure in the analytics-reporting vertical.