### PR TITLE
Fix dependency vulnerabilities and update lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "husky": "^9.1.7",
         "jscpd": "^4.0.5",
         "openapi-to-postmanv2": "^5.3.4",
+        "patch-package": "^8.0.1",
         "sql-lint": "^1.0.2",
         "supertest": "^7.1.4",
         "turbo": "^2.6.0",
@@ -4656,53 +4657,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@nozbe/simdjson": {
-      "version": "3.9.4",
-      "resolved": "https://registry.npmjs.org/@nozbe/simdjson/-/simdjson-3.9.4.tgz",
-      "integrity": "sha512-/3oCP8GBpdyeiBMEnuI6S0yl0yekD6Qxfed67hZqU1GIVn3o/vZgE8qANm69THfw7JgHLS9zjx56F/dO3q+koA==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@nozbe/sqlite": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@nozbe/sqlite/-/sqlite-3.46.0.tgz",
-      "integrity": "sha512-ntt8eNp5hh+axX9+kFb5uwyVE0edyfhiYYr+zHDzzFleGC7Qm+a2wHDWDtmRr5nSfbgomhY1uh30kpsHEIR3Mw=="
-    },
-    "node_modules/@nozbe/watermelondb": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@nozbe/watermelondb/-/watermelondb-0.28.0.tgz",
-      "integrity": "sha512-40ttcqPOLCTGnbfCQAXSEo8J4KlH/QQhwTfTb9E21CyX/driMEZueiJSI2rSkHICZrI2vnu52aRubNbI3UAzQQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "7.26.0",
-        "@nozbe/simdjson": "3.9.4",
-        "@nozbe/sqlite": "3.46.0",
-        "hoist-non-react-statics": "^3.3.2",
-        "lokijs": "npm:@nozbe/lokijs@1.5.12-wmelon6",
-        "rxjs": "^7.8.1",
-        "sql-escape-string": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@nozbe/watermelondb/node_modules/@babel/runtime": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
-      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
-      "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@nozbe/watermelondb/node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "license": "MIT"
-    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -8789,6 +8743,13 @@
         "@types/pg": "*"
       }
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/qs": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
@@ -8829,6 +8790,13 @@
       "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
+      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/send": {
       "version": "1.2.1",
@@ -9432,6 +9400,13 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -13589,6 +13564,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -16030,6 +16015,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -16060,6 +16065,16 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -16171,6 +16186,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kleur": {
@@ -18643,6 +18668,136 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/patch-package/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/patch-package/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/patch-package/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
       }
     },
     "node_modules/path-browserify": {
@@ -22414,6 +22569,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -24173,7 +24338,7 @@
       "dependencies": {
         "@care-commons/core": "file:../core",
         "@care-commons/time-tracking-evv": "file:../../verticals/time-tracking-evv",
-        "@nozbe/watermelondb": "^0.28.0",
+        "@nozbe/watermelondb": "^0.25.5",
         "@react-native-async-storage/async-storage": "~2.2.0",
         "@react-native-community/netinfo": "^11.4.1",
         "@react-navigation/bottom-tabs": "^7.8.2",
@@ -24218,6 +24383,86 @@
       },
       "engines": {
         "node": "22.x"
+      }
+    },
+    "packages/mobile/node_modules/@nozbe/simdjson": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@nozbe/simdjson/-/simdjson-1.0.0.tgz",
+      "integrity": "sha512-lm/MNUneznK65NNbmvawOn+OFYMjeBga+xEBACda4hTpZBnJhIgfLIxpYvx40sIeihRX0v7WiEB7VwQO9FIMAg==",
+      "license": "Apache-2.0"
+    },
+    "packages/mobile/node_modules/@nozbe/sqlite": {
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/@nozbe/sqlite/-/sqlite-3.36.0.tgz",
+      "integrity": "sha512-wKTFGvgf5V+bYlhXdukOWKH0XgdG0NmUQwLWG7w5Yk4EUeQS29D5uWPCeWT1Ac/NzDKuHsYP6KVOJDbJSauAAg=="
+    },
+    "packages/mobile/node_modules/@nozbe/watermelondb": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@nozbe/watermelondb/-/watermelondb-0.25.5.tgz",
+      "integrity": "sha512-/c84A7+3Ack8X8eFUXrvHMgIdk+Qz/3Vfkr5A2bQtHpXOLOGSbS6oXGdZTu+PYzLm4VlKZ68F9tF6yFVIVydiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.11.2",
+        "@nozbe/simdjson": "1.0.0",
+        "@nozbe/sqlite": "3.36.0",
+        "@nozbe/with-observables": "1.4.1",
+        "hoist-non-react-statics": "^3.3.2",
+        "lokijs": "npm:@nozbe/lokijs@1.5.12-wmelon6",
+        "rxjs": "^7.4.0",
+        "sql-escape-string": "^1.1.0"
+      }
+    },
+    "packages/mobile/node_modules/@nozbe/watermelondb/node_modules/@nozbe/with-observables": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@nozbe/with-observables/-/with-observables-1.4.1.tgz",
+      "integrity": "sha512-xsYrSeSzelFiWF/BXFZW+khFAqJdet22Egt6nhVLHGF2GmYbV5kxv8om0Wh2om4OXK6IM0UAU3pwk+nX5GLsUw==",
+      "license": "MIT",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "peerDependencies": {
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/react": "^16.9.23||^17",
+        "react": "^16.4.2||^17"
+      }
+    },
+    "packages/mobile/node_modules/@nozbe/watermelondb/node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
+      "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
+    "packages/mobile/node_modules/@nozbe/watermelondb/node_modules/@types/react": {
+      "version": "17.0.89",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.89.tgz",
+      "integrity": "sha512-I98SaDCar5lvEYl80ClRIUztH/hyWHR+I2f+5yTVp/MQ205HgYkA2b5mVdry/+nsEIrf8I65KA5V/PASx68MsQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "^0.16",
+        "csstype": "^3.0.2"
+      }
+    },
+    "packages/mobile/node_modules/@nozbe/watermelondb/node_modules/react": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "packages/shared-components": {
@@ -24269,7 +24514,7 @@
         "@care-commons/shared-components": "file:../shared-components",
         "@headlessui/react": "^2.2.9",
         "@hookform/resolvers": "^5.2.2",
-        "@nozbe/watermelondb": "^0.28.0",
+        "@nozbe/watermelondb": "^0.25.5",
         "@tanstack/react-query": "^5.90.7",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -24315,6 +24560,86 @@
       },
       "engines": {
         "node": "22.x"
+      }
+    },
+    "packages/web/node_modules/@nozbe/simdjson": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@nozbe/simdjson/-/simdjson-1.0.0.tgz",
+      "integrity": "sha512-lm/MNUneznK65NNbmvawOn+OFYMjeBga+xEBACda4hTpZBnJhIgfLIxpYvx40sIeihRX0v7WiEB7VwQO9FIMAg==",
+      "license": "Apache-2.0"
+    },
+    "packages/web/node_modules/@nozbe/sqlite": {
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/@nozbe/sqlite/-/sqlite-3.36.0.tgz",
+      "integrity": "sha512-wKTFGvgf5V+bYlhXdukOWKH0XgdG0NmUQwLWG7w5Yk4EUeQS29D5uWPCeWT1Ac/NzDKuHsYP6KVOJDbJSauAAg=="
+    },
+    "packages/web/node_modules/@nozbe/watermelondb": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@nozbe/watermelondb/-/watermelondb-0.25.5.tgz",
+      "integrity": "sha512-/c84A7+3Ack8X8eFUXrvHMgIdk+Qz/3Vfkr5A2bQtHpXOLOGSbS6oXGdZTu+PYzLm4VlKZ68F9tF6yFVIVydiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.11.2",
+        "@nozbe/simdjson": "1.0.0",
+        "@nozbe/sqlite": "3.36.0",
+        "@nozbe/with-observables": "1.4.1",
+        "hoist-non-react-statics": "^3.3.2",
+        "lokijs": "npm:@nozbe/lokijs@1.5.12-wmelon6",
+        "rxjs": "^7.4.0",
+        "sql-escape-string": "^1.1.0"
+      }
+    },
+    "packages/web/node_modules/@nozbe/watermelondb/node_modules/@nozbe/with-observables": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@nozbe/with-observables/-/with-observables-1.4.1.tgz",
+      "integrity": "sha512-xsYrSeSzelFiWF/BXFZW+khFAqJdet22Egt6nhVLHGF2GmYbV5kxv8om0Wh2om4OXK6IM0UAU3pwk+nX5GLsUw==",
+      "license": "MIT",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "peerDependencies": {
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/react": "^16.9.23||^17",
+        "react": "^16.4.2||^17"
+      }
+    },
+    "packages/web/node_modules/@nozbe/watermelondb/node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
+      "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
+    "packages/web/node_modules/@nozbe/watermelondb/node_modules/@types/react": {
+      "version": "17.0.89",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.89.tgz",
+      "integrity": "sha512-I98SaDCar5lvEYl80ClRIUztH/hyWHR+I2f+5yTVp/MQ205HgYkA2b5mVdry/+nsEIrf8I65KA5V/PASx68MsQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "^0.16",
+        "csstype": "^3.0.2"
+      }
+    },
+    "packages/web/node_modules/@nozbe/watermelondb/node_modules/react": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "packages/web/node_modules/@vitejs/plugin-react": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "husky": "^9.1.7",
     "jscpd": "^4.0.5",
     "openapi-to-postmanv2": "^5.3.4",
+    "patch-package": "^8.0.1",
     "sql-lint": "^1.0.2",
     "supertest": "^7.1.4",
     "turbo": "^2.6.0",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@care-commons/core": "file:../core",
     "@care-commons/time-tracking-evv": "file:../../verticals/time-tracking-evv",
-    "@nozbe/watermelondb": "^0.28.0",
+    "@nozbe/watermelondb": "^0.25.5",
     "@react-native-async-storage/async-storage": "~2.2.0",
     "@react-native-community/netinfo": "^11.4.1",
     "@react-navigation/bottom-tabs": "^7.8.2",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -28,7 +28,7 @@
     "@care-commons/shared-components": "file:../shared-components",
     "@headlessui/react": "^2.2.9",
     "@hookform/resolvers": "^5.2.2",
-    "@nozbe/watermelondb": "^0.28.0",
+    "@nozbe/watermelondb": "^0.25.5",
     "@tanstack/react-query": "^5.90.7",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",


### PR DESCRIPTION
…ng @nozbe/watermelondb

This commit addresses two issues:

1. Installation failure: Added patch-package as a devDependency to prevent installation failures when rollup's postinstall script tries to run patch-package

2. Security vulnerabilities: Fixed 2 moderate severity vulnerabilities by downgrading @nozbe/watermelondb from 0.28.0 to 0.25.5, which resolves the @babel/runtime RegExp complexity issue (GHSA-968p-4wvh-cqc8)

Changes:
- Added patch-package@^8.0.1 to root devDependencies
- Downgraded @nozbe/watermelondb from ^0.28.0 to ^0.25.5 in packages/mobile and packages/web
- Updated package-lock.json accordingly

Result: npm audit now reports 0 vulnerabilities