### PR TITLE
Fix linting error in web package

### DIFF
--- a/packages/web/src/demo/useDemoSession.ts
+++ b/packages/web/src/demo/useDemoSession.ts
@@ -73,9 +73,7 @@ export function useDemoSession(): UseDemoSessionResult {
       if (e.key === 'auth-storage' && e.newValue === null) {
         // Auth was cleared (user logged out), cleanup demo session
         void demoAPI.deleteSession(session.id)
-          .then(() => {
-            setSession(null);
-          })
+          .then(() => setSession(null))
           .catch((err: Error) => {
             console.error('Failed to cleanup demo session on logout:', err);
             // Still clear local session state even if API call fails


### PR DESCRIPTION
Changed .then() callback from block syntax to implicit return to satisfy the promise/always-return ESLint rule. This reduces the error count from 1 error + 343 warnings to just 343 warnings, allowing the lint task to pass.