### PR TITLE
Fix linting error in web package

### DIFF
--- a/packages/web/src/demo/useDemoSession.ts
+++ b/packages/web/src/demo/useDemoSession.ts
@@ -73,7 +73,9 @@ export function useDemoSession(): UseDemoSessionResult {
       if (e.key === 'auth-storage' && e.newValue === null) {
         // Auth was cleared (user logged out), cleanup demo session
         void demoAPI.deleteSession(session.id)
-          .then(() => setSession(null))
+          .then(() => {
+            return setSession(null);
+          })
           .catch((err: Error) => {
             console.error('Failed to cleanup demo session on logout:', err);
             // Still clear local session state even if API call fails


### PR DESCRIPTION
Fixed the promise/always-return ESLint error on line 76 by adding an explicit return statement in the .then() callback. Changed from:
  .then(() => setSession(null))
to:
  .then(() => { return setSession(null); })

This ensures the promise chain properly returns a value, satisfying the promise/always-return lint rule while avoiding the redundant-jump warning.