### PR TITLE
Update dependencies and fix TypeScript error

### DIFF
--- a/packages/web/src/showcase/ShowcaseRouter.tsx
+++ b/packages/web/src/showcase/ShowcaseRouter.tsx
@@ -40,6 +40,7 @@ export const ShowcaseRouter: React.FC = () => {
         return stored;
       }
     }
+    return undefined;
   });
 
   const handleRoleSelect = (roleId: string) => {


### PR DESCRIPTION
Add explicit return undefined to useState initializer function to ensure all code paths return a value. This fixes the TS7030 error that was preventing the type check from passing.