### PR TITLE
Fix TypeScript errors in web package

### DIFF
--- a/packages/web/src/showcase/ShowcaseRouter.tsx
+++ b/packages/web/src/showcase/ShowcaseRouter.tsx
@@ -40,6 +40,7 @@ export const ShowcaseRouter: React.FC = () => {
         return stored;
       }
     }
+    return undefined;
   });
 
   const handleRoleSelect = (roleId: string) => {
@@ -50,9 +51,8 @@ export const ShowcaseRouter: React.FC = () => {
       }
     }
     setShowRoleSelector(false);
-    navigate('/dashboard').catch(() => {
-      // Navigation error handling - silently fail as navigation is not critical
-    });
+    // eslint-disable-next-line sonarjs/void-use -- Required to suppress floating promise warning
+    void navigate('/dashboard');
   };
 
   const handleStartTour = () => {


### PR DESCRIPTION
- Add explicit undefined return to useState initializer to satisfy TypeScript's requirement that all code paths must return a value
- Replace navigate().catch() pattern with void operator to handle Promise<void> | void return type
- Add eslint-disable comment for sonarjs/void-use rule that flags void operator usage

These changes fix TypeScript compilation errors that appeared after upgrading dependencies, while maintaining compatibility with both TypeScript strict mode and eslint rules.