### PR TITLE
Fix npm cache error in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: npm install -g npm@10.9.4
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci || (npm cache clean --force && npm ci)
 
       - name: Run linting (Turbo)
         run: npx turbo run lint
@@ -61,7 +61,7 @@ jobs:
         run: npm install -g npm@10.9.4
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci || (npm cache clean --force && npm ci)
 
       - name: Run type checking (Turbo)
         run: npx turbo run typecheck
@@ -97,7 +97,7 @@ jobs:
         run: npm install -g npm@10.9.4
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci || (npm cache clean --force && npm ci)
 
       - name: Build packages (Turbo)
         run: npx turbo run build
@@ -171,7 +171,7 @@ jobs:
         run: npm install -g npm@10.9.4
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci || (npm cache clean --force && npm ci)
 
       - name: Build packages (Turbo)
         run: npx turbo run build


### PR DESCRIPTION
Add retry logic with cache cleanup to all npm ci steps to handle intermittent npm cache corruption errors (EEXIST/ENOENT) that can occur in GitHub Actions runners.

If npm ci fails, it will clean the cache and retry once automatically.