### PR TITLE
Fix missing tsx package dependency error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -349,7 +349,7 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: |
-          node --import tsx --no-warnings packages/core/scripts/seed-tx-fl-demo.ts
+          node --import tsx/esm --no-warnings packages/core/scripts/seed-tx-fl-demo.ts
 
   deployment-health-check:
     name: Verify Deployment Health

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -12,7 +12,7 @@
     "node": "22.x"
   },
   "scripts": {
-    "dev": "node --watch --import tsx --no-warnings src/server.ts",
+    "dev": "node --watch --import tsx/esm --no-warnings src/server.ts",
     "dev:watch": "tsc --watch",
     "build": "tsc && tsc-alias -p tsconfig.json",
     "build:vercel": "tsc -p tsconfig.vercel.json",


### PR DESCRIPTION
The --import tsx flag was causing module resolution errors because tsx's package.json uses exports field without a main field. When importing tsx directly, Node.js tried to resolve tsx/index.js which doesn't exist.

Changed to --import tsx/esm which correctly points to dist/esm/index.mjs as specified in tsx's exports field.

Fixes:
- packages/app dev script
- GitHub workflow seed script

Error was: Cannot find package 'node_modules/tsx/index.js'