### PR TITLE
Add Medication Management Link to Client Detail

### DIFF
--- a/packages/web/src/verticals/client-demographics/pages/ClientDetail.tsx
+++ b/packages/web/src/verticals/client-demographics/pages/ClientDetail.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
-import { ArrowLeft, Edit, Trash2, Phone, Mail, MapPin, Calendar, User } from 'lucide-react';
+import { ArrowLeft, Edit, Trash2, Phone, Mail, MapPin, Calendar, User, Pill } from 'lucide-react';
 import { Button, Card, CardHeader, CardContent, LoadingSpinner, ErrorMessage, StatusBadge } from '@/core/components';
 import { usePermissions } from '@/core/hooks';
 import { formatDate, formatPhone } from '@/core/utils';
@@ -203,6 +203,12 @@ export const ClientDetail: React.FC = () => {
             <CardHeader title="Quick Actions" />
             <CardContent>
               <div className="space-y-2">
+                <Link to={`/clients/${client.id}/medications`} className="block">
+                  <Button variant="outline" size="sm" className="w-full justify-start">
+                    <Pill className="h-4 w-4 mr-2" />
+                    View Medications
+                  </Button>
+                </Link>
                 <Button variant="outline" size="sm" className="w-full justify-start">
                   <Calendar className="h-4 w-4 mr-2" />
                   Schedule Visit


### PR DESCRIPTION
Add direct access to medication tracking from client detail page for improved caregiver workflow.

**Changes:**
- Add 'View Medications' button to Quick Actions section on client detail page
- Import Pill icon from lucide-react for visual clarity
- Link directly to /clients/:id/medications route
- Position as first action in Quick Actions (highest priority for caregivers)

**User Impact:**
Caregivers can now access client medications with one click from client profile, quickly mark medications as taken during visits, view medication schedules and compliance status, and see refill warnings.

**Implementation:**
- Updated ClientDetail.tsx with new action button
- Leverages existing MedicationListPage component (already built in PR #247)
- All routing and backend already in place
- All checks passing: lint ✅, typecheck ✅, tests ✅, build ✅

This improves the caregiver workflow by reducing navigation steps to access critical medication information during client visits.