### PR TITLE
Remove file watching from check script

### DIFF
--- a/verticals/analytics-reporting/package.json
+++ b/verticals/analytics-reporting/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "build": "tsc --composite false && tsc-alias -p tsconfig.json",
     "test": "vitest",
-    "test:coverage": "vitest --coverage",
+    "test:coverage": "vitest run --coverage",
     "lint": "eslint . --ext ts --max-warnings 10"
   },
   "dependencies": {


### PR DESCRIPTION
…orting

Changed the test:coverage script from 'vitest --coverage' to 'vitest run --coverage' to ensure it runs once and exits, matching all other packages in the monorepo. This prevents scripts/check.sh from hanging when running tests.