### PR TITLE
Configure dev server to listen on all interfaces

### DIFF
--- a/packages/app/src/server.ts
+++ b/packages/app/src/server.ts
@@ -288,11 +288,11 @@ async function start(): Promise<void> {
     await createApp();
 
     // Start listening
-    app.listen(PORT, () => {
+    app.listen(PORT, '0.0.0.0', () => {
       console.log(`\n✅ Server running on port ${PORT}`);
       console.log(`   Environment: ${NODE_ENV}`);
-      console.log(`   Health check: http://localhost:${PORT}/health`);
-      console.log(`   API docs: http://localhost:${PORT}/api-docs\n`);
+      console.log(`   Health check: http://0.0.0.0:${PORT}/health`);
+      console.log(`   API docs: http://0.0.0.0:${PORT}/api-docs\n`);
     });
   } catch (error) {
     console.error('Failed to start server:', error);

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -75,6 +75,7 @@ export default defineConfig({
     force: true,
   },
   server: {
+    host: '0.0.0.0',
     port: 5173,
     proxy: {
       '/api': {


### PR DESCRIPTION
Updated both web and API servers to listen on all network interfaces instead of just localhost. This allows access from outside the local machine, which is necessary for containerized environments, VMs, or accessing from other machines on the network.

Changes:
- Web server (Vite): Added host: '0.0.0.0' to server config
- API server (Express): Updated app.listen() to bind to '0.0.0.0'