### PR TITLE
Fix rate limiting trust proxy configuration error

### DIFF
--- a/packages/app/src/server.ts
+++ b/packages/app/src/server.ts
@@ -36,7 +36,9 @@ const NODE_ENV = process.env['NODE_ENV'] ?? 'development';
 
 // Trust proxy when behind reverse proxy (Vercel, etc.)
 // This allows Express to correctly read X-Forwarded-* headers for rate limiting and logging
-app.set('trust proxy', true);
+// IMPORTANT: Set to 1 (not true) to prevent IP spoofing - only trust the first proxy hop
+// See: https://express-rate-limit.github.io/ERR_ERL_PERMISSIVE_TRUST_PROXY/
+app.set('trust proxy', 1);
 
 /**
  * Initialize database connection


### PR DESCRIPTION
Change trust proxy setting from `true` to `1` to fix rate limiting ValidationError. Setting to `1` tells Express to trust only the first proxy hop (Vercel's infrastructure), preventing users from bypassing rate limiting by spoofing X-Forwarded-For headers.

This resolves the error:
ValidationError: The Express 'trust proxy' setting is true, which allows anyone to trivially bypass IP-based rate limiting.

See: https://express-rate-limit.github.io/ERR_ERL_PERMISSIVE_TRUST_PROXY/