### PR TITLE
Run test coverage and build all packages

### DIFF
--- a/packages/core/migrations/20251113000000_add_is_demo_data_column.ts
+++ b/packages/core/migrations/20251113000000_add_is_demo_data_column.ts
@@ -1,0 +1,73 @@
+/**
+ * Migration: Add is_demo_data Column
+ *
+ * Adds boolean column is_demo_data to tables to track which records
+ * are demo/test data vs real production data. This enables easy cleanup
+ * of demo data and prevents accidental mixing of test and real data.
+ */
+
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  // List of tables that need the is_demo_data column
+  const tables = [
+    'clients',
+    'caregivers',
+    'caregiver_certifications',
+    'visits',
+    'visit_evv_records',
+    'care_plans',
+    'task_instances',
+    'progress_notes',
+    'family_members',
+    'family_notifications',
+    'family_messages',
+    'invoices',
+    'shift_listings',
+    'shift_applications',
+    'users',
+  ];
+
+  for (const tableName of tables) {
+    // Add column if it doesn't exist
+    await knex.raw(`
+      ALTER TABLE ${tableName}
+      ADD COLUMN IF NOT EXISTS is_demo_data BOOLEAN DEFAULT false
+    `);
+
+    // Create index for efficient filtering
+    await knex.raw(`
+      CREATE INDEX IF NOT EXISTS idx_${tableName}_is_demo_data
+      ON ${tableName}(is_demo_data)
+      WHERE is_demo_data = true
+    `);
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const tables = [
+    'clients',
+    'caregivers',
+    'caregiver_certifications',
+    'visits',
+    'visit_evv_records',
+    'care_plans',
+    'task_instances',
+    'progress_notes',
+    'family_members',
+    'family_notifications',
+    'family_messages',
+    'invoices',
+    'shift_listings',
+    'shift_applications',
+    'users',
+  ];
+
+  for (const tableName of tables) {
+    // Drop indexes
+    await knex.raw(`DROP INDEX IF EXISTS idx_${tableName}_is_demo_data`);
+
+    // Drop columns
+    await knex.raw(`ALTER TABLE ${tableName} DROP COLUMN IF EXISTS is_demo_data`);
+  }
+}

--- a/packages/core/scripts/seed-demo.ts
+++ b/packages/core/scripts/seed-demo.ts
@@ -473,13 +473,12 @@ async function seedDatabase() {
       // ═══════════════════════════════════════════════════════════════════════════
       
       console.log('🧹 Clearing previous demo data (if any)...');
-      
+
       // Delete in reverse dependency order
-      await client.query('DELETE FROM visit_tasks WHERE is_demo_data = true');
       await client.query('DELETE FROM visit_evv_records WHERE is_demo_data = true');
       await client.query('DELETE FROM visits WHERE is_demo_data = true');
-      await client.query('DELETE FROM care_plan_tasks WHERE is_demo_data = true');
-      await client.query('DELETE FROM care_plan_goals WHERE is_demo_data = true');
+      await client.query('DELETE FROM task_instances WHERE is_demo_data = true');
+      await client.query('DELETE FROM progress_notes WHERE is_demo_data = true');
       await client.query('DELETE FROM care_plans WHERE is_demo_data = true');
       await client.query('DELETE FROM family_messages WHERE is_demo_data = true');
       await client.query('DELETE FROM family_notifications WHERE is_demo_data = true');


### PR DESCRIPTION
This commit fixes the database seeding error by:

1. Creating a new migration (20251113000000_add_is_demo_data_column.ts) that adds the is_demo_data boolean column to all tables that need it for tracking demo data
2. Fixing the seed-demo.ts script to reference the correct table names:
   - Removed reference to non-existent 'visit_tasks' table
   - Removed references to 'care_plan_tasks' and 'care_plan_goals' (don't exist)
   - Added correct table names: 'task_instances' and 'progress_notes'

The is_demo_data column enables easy cleanup of demo data and prevents mixing of test and production data.

Resolves: error: relation "visit_tasks" does not exist