### PR TITLE
Configure Redis for Vercel deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,11 +14,22 @@ DB_SSL=false
 # Note: Neon pooled connection strings are recommended for serverless
 
 # ════════════════════════════════════════════════════════════════
-# Redis Configuration (optional)
+# Redis Configuration (optional - for rate limiting and caching)
 # ════════════════════════════════════════════════════════════════
 # For local development with Docker:
 REDIS_URL=redis://localhost:6379
-# For production (Upstash, Redis Cloud, etc.):
+
+# For Vercel with Upstash Redis (recommended for production):
+# Get credentials from: https://console.upstash.com
+# REDIS_URL=rediss://default:your_password@your-endpoint.upstash.io:6379
+# Note: Use 'rediss://' (with double 's') for TLS connections
+
+# For Vercel KV (built on Upstash):
+# Automatically set by Vercel when you add Redis storage
+# KV_URL, KV_REST_API_URL, KV_REST_API_TOKEN (set by Vercel)
+# Map KV_URL to REDIS_URL in Vercel environment settings
+
+# Alternative: Redis Cloud, AWS ElastiCache, etc.
 # REDIS_URL=redis://username:password@host:port/db
 
 # Application

--- a/packages/app/src/config/redis.ts
+++ b/packages/app/src/config/redis.ts
@@ -2,28 +2,56 @@ import Redis from 'redis';
 
 let redisClient: Redis.RedisClientType | null = null;
 
+/**
+ * Initialize Redis client for general use
+ * Supports both local Redis and Upstash Redis (TLS)
+ */
 export const initRedis = async (): Promise<Redis.RedisClientType | null> => {
   const redisUrl = process.env.REDIS_URL;
   if (redisUrl === undefined || redisUrl === '') {
-    console.log('Redis not configured, using in-memory rate limiting');
+    console.log('Redis not configured, using in-memory fallback');
     return null;
   }
 
   try {
-    redisClient = Redis.createClient({ url: process.env.REDIS_URL });
+    // Determine if TLS is required based on URL protocol
+    // Upstash uses rediss:// for TLS connections
+    const useTLS = redisUrl.startsWith('rediss://');
+
+    const clientOptions: Redis.RedisClientOptions = {
+      url: redisUrl,
+    };
+
+    // Enable TLS for Upstash and other cloud Redis providers
+    if (useTLS) {
+      clientOptions.socket = {
+        tls: true,
+        // Disable certificate verification for Vercel deployments
+        // (Vercel's serverless functions may have issues with cert chains)
+        rejectUnauthorized: false,
+      };
+    }
+
+    redisClient = Redis.createClient(clientOptions);
 
     redisClient.on('error', (err) => {
-      console.error('Redis error:', err);
+      console.error('Redis client error:', err);
     });
 
     redisClient.on('connect', () => {
-      console.log('Redis connected successfully');
+      console.log(`Redis connected successfully (TLS: ${useTLS})`);
+    });
+
+    redisClient.on('reconnecting', () => {
+      console.log('Redis reconnecting...');
     });
 
     await redisClient.connect();
+    console.log('Redis connection established');
     return redisClient;
   } catch (error) {
     console.error('Failed to connect to Redis:', error);
+    console.log('Continuing without Redis - rate limiting will use in-memory store');
     return null;
   }
 };


### PR DESCRIPTION
Enable Redis to work seamlessly on Vercel with Upstash or Vercel KV by adding TLS support and automatic protocol detection.

Changes:
- Add TLS support for Redis connections (rediss:// protocol)
- Automatically detect TLS requirement from URL protocol
- Update redis.ts config with TLS options for Upstash
- Update rate-limit.ts middleware with TLS support
- Update cache.service.ts with TLS configuration
- Add comprehensive Vercel Redis setup documentation
- Update .env.example with Upstash/Vercel KV examples

Redis is used for:
- Distributed rate limiting across serverless functions
- Caching frequently accessed data
- Session storage (future)

Backward compatible:
- Local Redis (redis://) continues to work unchanged
- Graceful fallback to in-memory storage if Redis unavailable
- No breaking changes to existing deployments

Documentation:
- Added detailed Vercel Redis setup guide in CLAUDE.md
- Documented 3 options: Upstash, Vercel KV, In-Memory
- Included step-by-step setup instructions
- Added important notes about TLS and pricing