### PR TITLE
Fix Redis type compatibility errors in cache service

### DIFF
--- a/packages/app/src/config/redis.ts
+++ b/packages/app/src/config/redis.ts
@@ -32,22 +32,25 @@ export const initRedis = async (): Promise<Redis.RedisClientType | null> => {
       };
     }
 
-    redisClient = Redis.createClient(clientOptions);
+    const client = Redis.createClient(clientOptions);
 
-    redisClient.on('error', (err) => {
+    client.on('error', (err) => {
       console.error('Redis client error:', err);
     });
 
-    redisClient.on('connect', () => {
+    client.on('connect', () => {
       console.log(`Redis connected successfully (TLS: ${useTLS})`);
     });
 
-    redisClient.on('reconnecting', () => {
+    client.on('reconnecting', () => {
       console.log('Redis reconnecting...');
     });
 
-    await redisClient.connect();
+    await client.connect();
     console.log('Redis connection established');
+
+    // Only assign after successful connection
+    redisClient = client as Redis.RedisClientType;
     return redisClient;
   } catch (error) {
     console.error('Failed to connect to Redis:', error);

--- a/packages/core/src/service/cache.service.ts
+++ b/packages/core/src/service/cache.service.ts
@@ -45,17 +45,20 @@ export class CacheService {
         };
       }
 
-      this.redis = createClient(clientOptions);
+      const client = createClient(clientOptions);
 
-      this.redis.on('error', (err) => {
+      client.on('error', (err) => {
         console.error('Redis client error:', err);
         this.isRedisAvailable = false;
       });
 
-      await this.redis.connect();
+      await client.connect();
 
       // Test connection
-      await this.redis.ping();
+      await client.ping();
+
+      // Only assign after successful connection
+      this.redis = client as RedisClientType;
       this.isRedisAvailable = true;
       console.log(`Cache service: Redis connected successfully (TLS: ${useTLS})`);
     } catch (error) {


### PR DESCRIPTION
…ility

- Fix type incompatibility between createClient() return type and RedisClientType
- Add proper null safety checks for Redis client initialization
- Use local client variable before assigning to module/class property
- Apply consistent pattern in both @care-commons/core and @care-commons/app packages

Resolves TypeScript errors:
- TS2322: Type incompatibility with RedisClientType
- TS2531/TS18047: Object is possibly 'null' errors

Changes:
- packages/core/src/service/cache.service.ts
- packages/app/src/config/redis.ts