### PR TITLE
Fix Alabama admin login issue

### DIFF
--- a/packages/core/scripts/seed-demo.ts
+++ b/packages/core/scripts/seed-demo.ts
@@ -22,6 +22,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { faker } from '@faker-js/faker';
 import { Database, DatabaseConfig } from '../src/db/connection.js';
 import { Pool, PoolClient } from 'pg';
+import { PasswordUtils } from '../src/utils/password-utils.js';
 
 dotenvConfig({ path: '.env', quiet: true });
 
@@ -36,6 +37,122 @@ const SEED_CONFIG = {
   carePlans: 50,      // ~83% of clients have care plans
   familyMembers: 40,  // ~67% of clients have family portal access
 };
+
+// All 50 US States + DC
+const US_STATES = [
+  { code: 'AL', name: 'Alabama' },
+  { code: 'AK', name: 'Alaska' },
+  { code: 'AZ', name: 'Arizona' },
+  { code: 'AR', name: 'Arkansas' },
+  { code: 'CA', name: 'California' },
+  { code: 'CO', name: 'Colorado' },
+  { code: 'CT', name: 'Connecticut' },
+  { code: 'DE', name: 'Delaware' },
+  { code: 'FL', name: 'Florida' },
+  { code: 'GA', name: 'Georgia' },
+  { code: 'HI', name: 'Hawaii' },
+  { code: 'ID', name: 'Idaho' },
+  { code: 'IL', name: 'Illinois' },
+  { code: 'IN', name: 'Indiana' },
+  { code: 'IA', name: 'Iowa' },
+  { code: 'KS', name: 'Kansas' },
+  { code: 'KY', name: 'Kentucky' },
+  { code: 'LA', name: 'Louisiana' },
+  { code: 'ME', name: 'Maine' },
+  { code: 'MD', name: 'Maryland' },
+  { code: 'MA', name: 'Massachusetts' },
+  { code: 'MI', name: 'Michigan' },
+  { code: 'MN', name: 'Minnesota' },
+  { code: 'MS', name: 'Mississippi' },
+  { code: 'MO', name: 'Missouri' },
+  { code: 'MT', name: 'Montana' },
+  { code: 'NE', name: 'Nebraska' },
+  { code: 'NV', name: 'Nevada' },
+  { code: 'NH', name: 'New Hampshire' },
+  { code: 'NJ', name: 'New Jersey' },
+  { code: 'NM', name: 'New Mexico' },
+  { code: 'NY', name: 'New York' },
+  { code: 'NC', name: 'North Carolina' },
+  { code: 'ND', name: 'North Dakota' },
+  { code: 'OH', name: 'Ohio' },
+  { code: 'OK', name: 'Oklahoma' },
+  { code: 'OR', name: 'Oregon' },
+  { code: 'PA', name: 'Pennsylvania' },
+  { code: 'RI', name: 'Rhode Island' },
+  { code: 'SC', name: 'South Carolina' },
+  { code: 'SD', name: 'South Dakota' },
+  { code: 'TN', name: 'Tennessee' },
+  { code: 'TX', name: 'Texas' },
+  { code: 'UT', name: 'Utah' },
+  { code: 'VT', name: 'Vermont' },
+  { code: 'VA', name: 'Virginia' },
+  { code: 'WA', name: 'Washington' },
+  { code: 'WV', name: 'West Virginia' },
+  { code: 'WI', name: 'Wisconsin' },
+  { code: 'WY', name: 'Wyoming' },
+  { code: 'DC', name: 'District of Columbia' },
+] as const;
+
+// Role definitions for state-specific users
+interface RoleDefinition {
+  value: string;
+  label: string;
+  roles: string[];
+  permissions: string[];
+}
+
+const ROLES: RoleDefinition[] = [
+  {
+    value: 'ADMIN',
+    label: 'Administrator',
+    roles: ['SUPER_ADMIN'],
+    permissions: [
+      'organizations:*', 'users:*', 'clients:*', 'caregivers:*',
+      'visits:*', 'schedules:*', 'care-plans:*', 'billing:*',
+      'reports:*', 'settings:*'
+    ]
+  },
+  {
+    value: 'COORDINATOR',
+    label: 'Care Coordinator',
+    roles: ['COORDINATOR', 'SCHEDULER'],
+    permissions: [
+      'clients:create', 'clients:read', 'clients:update',
+      'caregivers:read', 'caregivers:assign',
+      'visits:create', 'visits:read', 'visits:update', 'visits:delete',
+      'schedules:create', 'schedules:read', 'schedules:update', 'schedules:delete',
+      'care-plans:create', 'care-plans:read', 'care-plans:update',
+      'reports:read', 'reports:generate'
+    ]
+  },
+  {
+    value: 'CAREGIVER',
+    label: 'Caregiver',
+    roles: ['CAREGIVER'],
+    permissions: [
+      'clients:read', 'visits:read', 'visits:clock-in', 'visits:clock-out',
+      'visits:update', 'care-plans:read', 'tasks:read', 'tasks:update'
+    ]
+  },
+  {
+    value: 'FAMILY',
+    label: 'Family Member',
+    roles: ['FAMILY'],
+    permissions: [
+      'clients:read', 'visits:read', 'care-plans:read', 'schedules:read'
+    ]
+  },
+  {
+    value: 'NURSE',
+    label: 'Nurse/Clinical',
+    roles: ['NURSE', 'CLINICAL'],
+    permissions: [
+      'clients:read', 'clients:update', 'visits:read', 'visits:create',
+      'visits:update', 'care-plans:create', 'care-plans:read',
+      'care-plans:update', 'medications:*', 'clinical:*'
+    ]
+  }
+];
 
 // ═══════════════════════════════════════════════════════════════════════════
 // HELPER FUNCTIONS
@@ -472,9 +589,135 @@ async function seedDatabase() {
       }
       
       const systemUserId = userResult.rows[0].id;
-      
+
       console.log(`✅ Using org: ${orgId}, branch: ${branchId}, user: ${systemUserId}\n`);
-      
+
+      // ═══════════════════════════════════════════════════════════════════════════
+      // STEP 1.5: Create state-specific users (all 50 states × 5 roles = 255 users)
+      // ═══════════════════════════════════════════════════════════════════════════
+
+      console.log(`👥 Creating state-specific demo users (${US_STATES.length} states × ${ROLES.length} roles = ${US_STATES.length * ROLES.length} users)...\n`);
+
+      let usersCreated = 0;
+      let usersUpdated = 0;
+
+      // Create users for each state × role combination
+      for (const state of US_STATES) {
+        for (const role of ROLES) {
+          const stateCode = state.code.toLowerCase();
+          const roleCode = role.value.toLowerCase();
+
+          // Email format: role@state.carecommons.example
+          const email = `${roleCode}@${stateCode}.carecommons.example`;
+          const username = `${roleCode}-${stateCode}`;
+          const firstName = role.label;
+          const lastName = `(${state.code})`;
+
+          // Password format: Demo{State}{Role}123!
+          const password = `Demo${state.code}${role.value}123!`;
+          const passwordHash = PasswordUtils.hashPassword(password);
+
+          const userId = uuidv4();
+
+          try {
+            // Try to update existing user first
+            const updateResult = await client.query(
+              `
+              UPDATE users
+              SET
+                password_hash = $1,
+                first_name = $2,
+                last_name = $3,
+                roles = $4,
+                permissions = $5,
+                status = 'ACTIVE',
+                branch_ids = $6,
+                updated_at = NOW()
+              WHERE email = $7
+              RETURNING id
+              `,
+              [
+                passwordHash,
+                firstName,
+                lastName,
+                role.roles,
+                role.permissions,
+                [branchId],
+                email
+              ]
+            );
+
+            if (updateResult.rows.length > 0) {
+              usersUpdated++;
+            } else {
+              // User doesn't exist, create new one
+              await client.query(
+                `
+                INSERT INTO users (
+                  id, organization_id, username, email, password_hash,
+                  first_name, last_name, roles, permissions, branch_ids,
+                  status, created_by, updated_by
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+                `,
+                [
+                  userId,
+                  orgId,
+                  username,
+                  email,
+                  passwordHash,
+                  firstName,
+                  lastName,
+                  role.roles,
+                  role.permissions,
+                  [branchId],
+                  'ACTIVE',
+                  systemUserId,
+                  systemUserId
+                ]
+              );
+              usersCreated++;
+            }
+          } catch (error) {
+            if (error instanceof Error && 'code' in error && error.code === '23505') {
+              // Unique constraint violation - try updating by username
+              await client.query(
+                `
+                UPDATE users
+                SET
+                  email = $1,
+                  password_hash = $2,
+                  first_name = $3,
+                  last_name = $4,
+                  roles = $5,
+                  permissions = $6,
+                  status = 'ACTIVE',
+                  branch_ids = $7,
+                  updated_at = NOW()
+                WHERE username = $8
+                `,
+                [
+                  email,
+                  passwordHash,
+                  firstName,
+                  lastName,
+                  role.roles,
+                  role.permissions,
+                  [branchId],
+                  username
+                ]
+              );
+              usersUpdated++;
+            } else {
+              throw error;
+            }
+          }
+        }
+      }
+
+      console.log(`✅ State-specific users: ${usersCreated} created, ${usersUpdated} updated (${usersCreated + usersUpdated} total)\n`);
+      console.log(`📝 Login format: {role}@{state}.carecommons.example / Demo{STATE}{ROLE}123!`);
+      console.log(`   Example: admin@al.carecommons.example / DemoALADMIN123!\n`);
+
       // ═══════════════════════════════════════════════════════════════════════════
       // STEP 2: Clear existing demo data (optional, based on IS_DEMO flag)
       // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Integrate state-specific user creation into the demo seed script. This fixes the issue where Alabama admin login (and all other state-specific logins) failed because these users were never created.

Changes:
- Add PasswordUtils import to seed-demo.ts
- Add US_STATES and ROLES constants (all 50 states + DC, 5 roles)
- Create new STEP 1.5 to seed 255 state-specific users (51 states × 5 roles)
- Users are created with upsert logic (update existing, insert new)

Total users created: 51 states × 5 roles = 255 users

Login pattern:
- Email: {role}@{state}.carecommons.example
- Password: Demo{STATE}{ROLE}123!

Examples:
- admin@al.carecommons.example / DemoALADMIN123! (Alabama admin)
- admin@tx.carecommons.example / DemoTXADMIN123! (Texas admin)
- caregiver@ca.carecommons.example / DemoCACAREGIVER123! (California caregiver)

Resolves login failures for state-specific demo accounts. Users are now created automatically when running npm run db:seed:demo.