### PR TITLE
Fix 403 Forbidden error on tasks page

### DIFF
--- a/packages/core/scripts/seed-all-states-users.ts
+++ b/packages/core/scripts/seed-all-states-users.ts
@@ -98,6 +98,7 @@ const ROLES: RoleDefinition[] = [
       'visits:*',
       'schedules:*',
       'care-plans:*',
+      'tasks:*',
       'billing:*',
       'reports:*',
       'settings:*'
@@ -124,6 +125,9 @@ const ROLES: RoleDefinition[] = [
       'care-plans:create',
       'care-plans:read',
       'care-plans:update',
+      'tasks:create',
+      'tasks:read',
+      'tasks:update',
       'reports:read',
       'reports:generate'
     ]
@@ -151,6 +155,7 @@ const ROLES: RoleDefinition[] = [
       'clients:read',
       'visits:read',
       'care-plans:read',
+      'tasks:read',
       'schedules:read'
     ]
   },
@@ -167,6 +172,9 @@ const ROLES: RoleDefinition[] = [
       'care-plans:create',
       'care-plans:read',
       'care-plans:update',
+      'tasks:create',
+      'tasks:read',
+      'tasks:update',
       'medications:*',
       'clinical:*'
     ]

--- a/packages/core/scripts/seed-demo.ts
+++ b/packages/core/scripts/seed-demo.ts
@@ -108,7 +108,7 @@ const ROLES: RoleDefinition[] = [
     roles: ['SUPER_ADMIN'],
     permissions: [
       'organizations:*', 'users:*', 'clients:*', 'caregivers:*',
-      'visits:*', 'schedules:*', 'care-plans:*', 'billing:*',
+      'visits:*', 'schedules:*', 'care-plans:*', 'tasks:*', 'billing:*',
       'reports:*', 'settings:*'
     ]
   },
@@ -122,6 +122,7 @@ const ROLES: RoleDefinition[] = [
       'visits:create', 'visits:read', 'visits:update', 'visits:delete',
       'schedules:create', 'schedules:read', 'schedules:update', 'schedules:delete',
       'care-plans:create', 'care-plans:read', 'care-plans:update',
+      'tasks:create', 'tasks:read', 'tasks:update',
       'reports:read', 'reports:generate'
     ]
   },
@@ -139,7 +140,7 @@ const ROLES: RoleDefinition[] = [
     label: 'Family Member',
     roles: ['FAMILY'],
     permissions: [
-      'clients:read', 'visits:read', 'care-plans:read', 'schedules:read'
+      'clients:read', 'visits:read', 'care-plans:read', 'tasks:read', 'schedules:read'
     ]
   },
   {
@@ -149,7 +150,8 @@ const ROLES: RoleDefinition[] = [
     permissions: [
       'clients:read', 'clients:update', 'visits:read', 'visits:create',
       'visits:update', 'care-plans:create', 'care-plans:read',
-      'care-plans:update', 'medications:*', 'clinical:*'
+      'care-plans:update', 'tasks:create', 'tasks:read', 'tasks:update',
+      'medications:*', 'clinical:*'
     ]
   }
 ];

--- a/packages/core/scripts/seed-users.ts
+++ b/packages/core/scripts/seed-users.ts
@@ -44,6 +44,7 @@ const USER_ACCOUNTS: UserAccount[] = [
       'visits:*',
       'schedules:*',
       'care-plans:*',
+      'tasks:*',
       'billing:*',
       'reports:*',
       'settings:*'
@@ -60,6 +61,7 @@ const USER_ACCOUNTS: UserAccount[] = [
       'clients:read',
       'visits:read',
       'care-plans:read',
+      'tasks:read',
       'schedules:read'
     ],
     description: 'Family member with read-only access to care information',
@@ -88,6 +90,9 @@ const USER_ACCOUNTS: UserAccount[] = [
       'care-plans:create',
       'care-plans:read',
       'care-plans:update',
+      'tasks:create',
+      'tasks:read',
+      'tasks:update',
       'reports:read',
       'reports:generate'
     ],

--- a/packages/core/scripts/seed.ts
+++ b/packages/core/scripts/seed.ts
@@ -135,14 +135,15 @@ async function seedDatabase() {
         `
         INSERT INTO users (
           id, organization_id, username, email, password_hash,
-          first_name, last_name, roles, branch_ids, status,
+          first_name, last_name, roles, permissions, branch_ids, status,
           created_by, updated_by
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
         ON CONFLICT (email) DO UPDATE SET
           password_hash = EXCLUDED.password_hash,
           first_name = EXCLUDED.first_name,
           last_name = EXCLUDED.last_name,
           roles = EXCLUDED.roles,
+          permissions = EXCLUDED.permissions,
           status = EXCLUDED.status,
           updated_at = NOW()
       `,
@@ -155,6 +156,7 @@ async function seedDatabase() {
           'System',
           'Administrator',
           ['SUPER_ADMIN'],
+          ['organizations:*', 'users:*', 'clients:*', 'caregivers:*', 'visits:*', 'schedules:*', 'care-plans:*', 'tasks:*', 'billing:*', 'reports:*', 'settings:*'],
           [branchId],
           'ACTIVE',
           systemUserId,
@@ -194,7 +196,7 @@ async function seedDatabase() {
           'Stein',
           'Family',
           ['FAMILY'],
-          ['clients:read', 'visits:read', 'care-plans:read', 'schedules:read'],
+          ['clients:read', 'visits:read', 'care-plans:read', 'tasks:read', 'schedules:read'],
           [branchId],
           'ACTIVE',
           systemUserId,


### PR DESCRIPTION
- Add tasks:* permission to admin users for full task management access
- Add tasks:read, tasks:create, tasks:update to coordinator users
- Add tasks:read to family users for viewing tasks
- Add tasks:create, tasks:read, tasks:update to nurse users

This fixes the 403 error on the /tasks page where users were denied access due to missing 'tasks:read' permission. The permission checks in CarePlanService.searchTaskInstances() require 'tasks:read', but users only had 'care-plans:*' which wasn't being matched properly.

Updated seed scripts:
- packages/core/scripts/seed.ts
- packages/core/scripts/seed-users.ts
- packages/core/scripts/seed-all-states-users.ts
- packages/core/scripts/seed-demo.ts

Fixes: #3 (Tasks Page Error - 403 Forbidden)