### PR TITLE
Add missing "Add Client" button to empty state

### DIFF
--- a/packages/web/src/verticals/client-demographics/pages/ClientList.tsx
+++ b/packages/web/src/verticals/client-demographics/pages/ClientList.tsx
@@ -77,13 +77,15 @@ export const ClientList: React.FC = () => {
           title="No clients found"
           description="Get started by creating your first client."
           action={
-            can('clients:write') ? (
-              <Link to="/clients/new">
-                <Button leftIcon={<Plus className="h-4 w-4" />}>
-                  Create Client
-                </Button>
-              </Link>
-            ) : undefined
+            <Link to="/clients/new">
+              <Button
+                leftIcon={<Plus className="h-4 w-4" />}
+                disabled={!can('clients:write')}
+                title={!can('clients:write') ? 'You do not have permission to create clients' : undefined}
+              >
+                Create Client
+              </Button>
+            </Link>
           }
         />
       ) : (


### PR DESCRIPTION
Previously, the 'Create Client' button in the empty state was only shown to users with 'clients:write' permission. This created a confusing UX where users saw the message "Get started by creating your first client" but no action button.

Changes:
- The 'Create Client' button is now always visible in the empty state
- Button is disabled for users without 'clients:write' permission
- Added tooltip explaining lack of permission when button is disabled
- Maintains security by keeping route-level permission checks

Fixes issue where empty state showed message without call-to-action button for users without write permissions.