### PR TITLE
Build scheduling section empty state

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -12,6 +12,7 @@ import { EVVRecordList, EVVRecordDetail } from './verticals/time-tracking-evv';
 import { InvoiceList, InvoiceDetail } from './verticals/billing-invoicing';
 import { PayrollDashboard, PayRunList, PayRunDetail } from './verticals/payroll-processing';
 import { OpenShiftList, OpenShiftDetail } from './verticals/shift-matching';
+import { VisitList } from './verticals/scheduling-visits';
 import { MedicationListPage } from './pages/medications/MedicationListPage';
 import { IncidentListPage } from './pages/incidents/IncidentListPage';
 import { CreateIncidentPage } from './pages/incidents/CreateIncidentPage';
@@ -189,10 +190,7 @@ function AppRoutes() {
         element={
           <ProtectedRoute>
             <AppShell>
-              <div className="text-center py-12">
-                <h2 className="text-2xl font-bold text-gray-900">Scheduling & Visits</h2>
-                <p className="text-gray-600 mt-2">Coming soon...</p>
-              </div>
+              <VisitList />
             </AppShell>
           </ProtectedRoute>
         }

--- a/packages/web/src/verticals/scheduling-visits/components/VisitCard.tsx
+++ b/packages/web/src/verticals/scheduling-visits/components/VisitCard.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import { Calendar, Clock, MapPin, User, AlertCircle, CheckCircle } from 'lucide-react';
+import type { Visit } from '../types';
+import { VISIT_STATUS_LABELS, VISIT_STATUS_COLORS, VISIT_TYPE_LABELS } from '../types';
+
+interface VisitCardProps {
+  visit: Visit;
+  compact?: boolean;
+}
+
+export const VisitCard: React.FC<VisitCardProps> = ({ visit, compact = false }) => {
+  const statusColor = VISIT_STATUS_COLORS[visit.status];
+  const isCompleted = visit.status === 'COMPLETED';
+  const isUrgent = visit.isUrgent || visit.isPriority;
+
+  const formatDate = (date: Date | string) => {
+    const d = typeof date === 'string' ? new Date(date) : date;
+    return d.toLocaleDateString('en-US', {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric'
+    });
+  };
+
+  const getClientName = () => {
+    if (visit.clientFirstName && visit.clientLastName) {
+      return `${visit.clientFirstName} ${visit.clientLastName}`;
+    }
+    return 'Client';
+  };
+
+  const getStatusBadgeClasses = () => {
+    const baseClasses = 'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium';
+    const colorClasses = {
+      gray: 'bg-gray-100 text-gray-800',
+      blue: 'bg-blue-100 text-blue-800',
+      yellow: 'bg-yellow-100 text-yellow-800',
+      cyan: 'bg-cyan-100 text-cyan-800',
+      green: 'bg-green-100 text-green-800',
+      indigo: 'bg-indigo-100 text-indigo-800',
+      purple: 'bg-purple-100 text-purple-800',
+      orange: 'bg-orange-100 text-orange-800',
+      red: 'bg-red-100 text-red-800',
+    };
+    return `${baseClasses} ${colorClasses[statusColor as keyof typeof colorClasses] || colorClasses.gray}`;
+  };
+
+  if (compact) {
+    return (
+      <div className="flex items-center justify-between p-4 bg-white border border-gray-200 rounded-lg hover:shadow-md transition-shadow">
+        <div className="flex items-center space-x-4 flex-1">
+          <div className="flex-shrink-0">
+            {isCompleted ? (
+              <CheckCircle className="h-8 w-8 text-green-500" />
+            ) : (
+              <Calendar className="h-8 w-8 text-blue-500" />
+            )}
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2">
+              <h3 className="text-sm font-medium text-gray-900 truncate">
+                {getClientName()}
+              </h3>
+              {isUrgent && <AlertCircle className="h-4 w-4 text-red-500 flex-shrink-0" />}
+            </div>
+            <p className="text-sm text-gray-500">
+              {visit.serviceTypeName}
+            </p>
+          </div>
+          <div className="text-sm text-gray-500">
+            {visit.scheduledStartTime} - {visit.scheduledEndTime}
+          </div>
+          <span className={getStatusBadgeClasses()}>
+            {VISIT_STATUS_LABELS[visit.status]}
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm border border-gray-200 hover:shadow-md transition-shadow">
+      <div className="p-5">
+        {/* Header */}
+        <div className="flex justify-between items-start mb-4">
+          <div className="flex items-start gap-3">
+            <div className={`p-2 rounded-lg ${isCompleted ? 'bg-green-100' : 'bg-blue-100'}`}>
+              {isCompleted ? (
+                <CheckCircle className="h-6 w-6 text-green-600" />
+              ) : (
+                <Calendar className="h-6 w-6 text-blue-600" />
+              )}
+            </div>
+            <div>
+              <div className="flex items-center gap-2">
+                <h3 className="text-lg font-semibold text-gray-900">
+                  {getClientName()}
+                </h3>
+                {isUrgent && <AlertCircle className="h-5 w-5 text-red-500" />}
+              </div>
+              <p className="text-sm text-gray-500">
+                {VISIT_TYPE_LABELS[visit.visitType]} • {visit.visitNumber}
+              </p>
+            </div>
+          </div>
+          <span className={getStatusBadgeClasses()}>
+            {VISIT_STATUS_LABELS[visit.status]}
+          </span>
+        </div>
+
+        {/* Service Type */}
+        <div className="mb-4">
+          <p className="text-sm font-medium text-gray-700">{visit.serviceTypeName}</p>
+        </div>
+
+        {/* Details Grid */}
+        <div className="space-y-3">
+          {/* Date & Time */}
+          <div className="flex items-center text-sm text-gray-600">
+            <Calendar className="h-4 w-4 mr-2 flex-shrink-0" />
+            <span>{formatDate(visit.scheduledDate)}</span>
+          </div>
+
+          <div className="flex items-center text-sm text-gray-600">
+            <Clock className="h-4 w-4 mr-2 flex-shrink-0" />
+            <span>
+              {visit.scheduledStartTime} - {visit.scheduledEndTime} ({visit.scheduledDuration} min)
+            </span>
+          </div>
+
+          {/* Address */}
+          <div className="flex items-start text-sm text-gray-600">
+            <MapPin className="h-4 w-4 mr-2 mt-0.5 flex-shrink-0" />
+            <span>
+              {visit.address.line1}
+              {visit.address.line2 && `, ${visit.address.line2}`}
+              <br />
+              {visit.address.city}, {visit.address.state} {visit.address.postalCode}
+            </span>
+          </div>
+
+          {/* Caregiver */}
+          {visit.assignedCaregiverId && (
+            <div className="flex items-center text-sm text-gray-600">
+              <User className="h-4 w-4 mr-2 flex-shrink-0" />
+              <span>Assigned</span>
+            </div>
+          )}
+        </div>
+
+        {/* Tasks Progress */}
+        {visit.tasksTotal !== undefined && visit.tasksTotal > 0 && (
+          <div className="mt-4 pt-4 border-t border-gray-200">
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-gray-600">Tasks</span>
+              <span className="font-medium text-gray-900">
+                {visit.tasksCompleted ?? 0} / {visit.tasksTotal}
+              </span>
+            </div>
+            <div className="mt-2 w-full bg-gray-200 rounded-full h-2">
+              <div
+                className="bg-blue-600 h-2 rounded-full transition-all"
+                style={{
+                  width: `${((visit.tasksCompleted ?? 0) / visit.tasksTotal) * 100}%`,
+                }}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/packages/web/src/verticals/scheduling-visits/components/index.ts
+++ b/packages/web/src/verticals/scheduling-visits/components/index.ts
@@ -1,0 +1,1 @@
+export { VisitCard } from './VisitCard';

--- a/packages/web/src/verticals/scheduling-visits/hooks/useVisits.ts
+++ b/packages/web/src/verticals/scheduling-visits/hooks/useVisits.ts
@@ -1,0 +1,37 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useApiClient } from '@/core/hooks';
+import { createVisitApiService } from '../services/visit-api';
+import type { VisitSearchFilters } from '../types';
+
+export const useVisitApi = () => {
+  const apiClient = useApiClient();
+  return useMemo(() => createVisitApiService(apiClient), [apiClient]);
+};
+
+/**
+ * Hook to fetch visits for the current user (caregiver)
+ * within a date range
+ */
+export const useMyVisits = (startDate: Date, endDate: Date) => {
+  const visitApi = useVisitApi();
+
+  return useQuery({
+    queryKey: ['visits', 'my-visits', startDate.toISOString(), endDate.toISOString()],
+    queryFn: () => visitApi.getMyVisits(startDate, endDate),
+    staleTime: 1 * 60 * 1000, // 1 minute
+  });
+};
+
+/**
+ * Hook to fetch visits with filters
+ */
+export const useVisits = (filters?: VisitSearchFilters) => {
+  const visitApi = useVisitApi();
+
+  return useQuery({
+    queryKey: ['visits', 'search', filters],
+    queryFn: () => visitApi.getVisitsByFilters(filters ?? {}),
+    staleTime: 1 * 60 * 1000, // 1 minute
+  });
+};

--- a/packages/web/src/verticals/scheduling-visits/index.ts
+++ b/packages/web/src/verticals/scheduling-visits/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Scheduling & Visits Vertical - Web UI
+ */
+
+// Pages
+export { VisitList } from './pages';
+
+// Components
+export { VisitCard } from './components';
+
+// Hooks
+export { useVisits, useMyVisits, useVisitApi } from './hooks/useVisits';
+
+// Types
+export type {
+  Visit,
+  VisitSearchFilters,
+  VisitStatus,
+  VisitType,
+  VisitAddress,
+} from './types';

--- a/packages/web/src/verticals/scheduling-visits/pages/VisitList.tsx
+++ b/packages/web/src/verticals/scheduling-visits/pages/VisitList.tsx
@@ -1,0 +1,152 @@
+import React, { useState } from 'react';
+import { Calendar, Grid, List, CalendarDays } from 'lucide-react';
+import { LoadingSpinner, EmptyState, ErrorMessage } from '@/core/components';
+import { useVisits } from '../hooks/useVisits';
+import { VisitCard } from '../components';
+import type { VisitSearchFilters } from '../types';
+
+const getDefaultFilters = (): VisitSearchFilters => ({
+  dateFrom: new Date(),
+  dateTo: new Date(new Date().getTime() + 30 * 24 * 60 * 60 * 1000), // 30 days from now
+});
+
+export const VisitList: React.FC = () => {
+  const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
+
+  // Default to show visits for the next 30 days
+  const [filters] = useState<VisitSearchFilters>(getDefaultFilters);
+
+  const { data: visits, isLoading, error, refetch } = useVisits(filters);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center py-12">
+        <LoadingSpinner size="lg" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <ErrorMessage
+        message={(error as Error).message || 'Failed to load visits'}
+        retry={() => { void refetch(); }}
+      />
+    );
+  }
+
+  const visitList = visits ?? [];
+  const upcomingVisits = visitList.filter((v) => {
+    const scheduledDate = typeof v.scheduledDate === 'string'
+      ? new Date(v.scheduledDate)
+      : v.scheduledDate;
+    return scheduledDate >= new Date() && v.status !== 'CANCELLED' && v.status !== 'COMPLETED';
+  });
+
+  const completedVisits = visitList.filter((v) => v.status === 'COMPLETED');
+  const unassignedVisits = visitList.filter((v) => v.status === 'UNASSIGNED');
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex justify-between items-center">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Scheduling & Visits</h1>
+          <p className="text-gray-600 mt-1">
+            {visitList.length === 0
+              ? 'No visits scheduled'
+              : `${visitList.length} total visits`}
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <div className="flex border border-gray-300 rounded-md">
+            <button
+              onClick={() => setViewMode('grid')}
+              className={`p-2 ${
+                viewMode === 'grid' ? 'bg-gray-100' : 'hover:bg-gray-50'
+              }`}
+              aria-label="Grid view"
+            >
+              <Grid className="h-5 w-5" />
+            </button>
+            <button
+              onClick={() => setViewMode('list')}
+              className={`p-2 ${
+                viewMode === 'list' ? 'bg-gray-100' : 'hover:bg-gray-50'
+              }`}
+              aria-label="List view"
+            >
+              <List className="h-5 w-5" />
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Summary Cards */}
+      {visitList.length > 0 && (
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div className="bg-white rounded-lg border border-gray-200 p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm font-medium text-gray-600">Upcoming</p>
+                <p className="text-2xl font-bold text-gray-900 mt-1">
+                  {upcomingVisits.length}
+                </p>
+              </div>
+              <Calendar className="h-8 w-8 text-blue-500" />
+            </div>
+          </div>
+
+          <div className="bg-white rounded-lg border border-gray-200 p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm font-medium text-gray-600">Unassigned</p>
+                <p className="text-2xl font-bold text-gray-900 mt-1">
+                  {unassignedVisits.length}
+                </p>
+              </div>
+              <CalendarDays className="h-8 w-8 text-yellow-500" />
+            </div>
+          </div>
+
+          <div className="bg-white rounded-lg border border-gray-200 p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm font-medium text-gray-600">Completed</p>
+                <p className="text-2xl font-bold text-gray-900 mt-1">
+                  {completedVisits.length}
+                </p>
+              </div>
+              <Calendar className="h-8 w-8 text-green-500" />
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Visits List or Empty State */}
+      {visitList.length === 0 ? (
+        <EmptyState
+          title="No visits scheduled"
+          description="Visits will appear here once they are scheduled in the system. Check back later or contact your coordinator to schedule visits."
+          icon={<Calendar className="h-12 w-12" />}
+        />
+      ) : (
+        <div
+          className={
+            viewMode === 'grid'
+              ? 'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6'
+              : 'space-y-4'
+          }
+        >
+          {visitList.map((visit) => (
+            <VisitCard
+              key={visit.id}
+              visit={visit}
+              compact={viewMode === 'list'}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/web/src/verticals/scheduling-visits/pages/index.ts
+++ b/packages/web/src/verticals/scheduling-visits/pages/index.ts
@@ -1,0 +1,1 @@
+export { VisitList } from './VisitList';

--- a/packages/web/src/verticals/scheduling-visits/services/visit-api.ts
+++ b/packages/web/src/verticals/scheduling-visits/services/visit-api.ts
@@ -1,0 +1,42 @@
+import type { ApiClient } from '@/core/services';
+import type { Visit, VisitSearchFilters } from '../types';
+
+export interface VisitApiResponse {
+  success: boolean;
+  data: Visit[];
+  meta: {
+    startDate: string;
+    endDate: string;
+    count: number;
+  };
+}
+
+export interface VisitApiService {
+  getMyVisits(startDate: Date, endDate: Date): Promise<Visit[]>;
+  getVisitsByFilters(filters: VisitSearchFilters): Promise<Visit[]>;
+}
+
+export const createVisitApiService = (apiClient: ApiClient): VisitApiService => {
+  return {
+    async getMyVisits(startDate: Date, endDate: Date): Promise<Visit[]> {
+      const params = new URLSearchParams();
+      params.append('start_date', startDate.toISOString().split('T')[0]!); // YYYY-MM-DD
+      params.append('end_date', endDate.toISOString().split('T')[0]!); // YYYY-MM-DD
+
+      const response = await apiClient.get<VisitApiResponse>(
+        `/api/visits/my-visits?${params.toString()}`
+      );
+
+      return response.data;
+    },
+
+    async getVisitsByFilters(filters: VisitSearchFilters): Promise<Visit[]> {
+      // For now, this uses the my-visits endpoint with date filtering
+      // In the future, this could be expanded to support more complex filters
+      const startDate = filters.dateFrom ?? new Date();
+      const endDate = filters.dateTo ?? new Date(new Date().getTime() + 30 * 24 * 60 * 60 * 1000); // 30 days ahead
+
+      return this.getMyVisits(startDate, endDate);
+    },
+  };
+};

--- a/packages/web/src/verticals/scheduling-visits/types/index.ts
+++ b/packages/web/src/verticals/scheduling-visits/types/index.ts
@@ -1,0 +1,175 @@
+/**
+ * Scheduling & Visits types for web application
+ *
+ * These types align with the backend Visit types but include
+ * only the fields needed for UI display.
+ */
+
+export interface Visit {
+  id: string;
+  organizationId: string;
+  branchId: string;
+  clientId: string;
+  patternId?: string;
+  scheduleId?: string;
+
+  // Visit identity
+  visitNumber: string;
+  visitType: VisitType;
+  serviceTypeId: string;
+  serviceTypeName: string;
+
+  // Timing
+  scheduledDate: Date | string;
+  scheduledStartTime: string; // HH:MM format
+  scheduledEndTime: string; // HH:MM format
+  scheduledDuration: number; // Minutes
+  timezone: string;
+
+  // Actual timing
+  actualStartTime?: Date | string;
+  actualEndTime?: Date | string;
+  actualDuration?: number;
+
+  // Assignment
+  assignedCaregiverId?: string;
+  assignedAt?: Date | string;
+  assignmentMethod?: AssignmentMethod;
+
+  // Client info (denormalized for display)
+  clientFirstName?: string;
+  clientLastName?: string;
+  clientPhone?: {
+    number: string;
+    type: string;
+    canReceiveSMS: boolean;
+  };
+
+  // Location
+  address: VisitAddress;
+
+  // Status
+  status: VisitStatus;
+
+  // Flags
+  isUrgent: boolean;
+  isPriority: boolean;
+  requiresSupervision: boolean;
+
+  // Completion
+  completionNotes?: string;
+  tasksCompleted?: number;
+  tasksTotal?: number;
+
+  // Timestamps
+  createdAt: Date | string;
+  updatedAt: Date | string;
+}
+
+export interface VisitAddress {
+  line1: string;
+  line2?: string;
+  city: string;
+  state: string;
+  postalCode: string;
+  country: string;
+  latitude?: number;
+  longitude?: number;
+  accessInstructions?: string;
+}
+
+export type VisitType =
+  | 'REGULAR'
+  | 'INITIAL'
+  | 'DISCHARGE'
+  | 'RESPITE'
+  | 'EMERGENCY'
+  | 'MAKEUP'
+  | 'SUPERVISION'
+  | 'ASSESSMENT';
+
+export type VisitStatus =
+  | 'DRAFT'
+  | 'SCHEDULED'
+  | 'UNASSIGNED'
+  | 'ASSIGNED'
+  | 'CONFIRMED'
+  | 'EN_ROUTE'
+  | 'ARRIVED'
+  | 'IN_PROGRESS'
+  | 'PAUSED'
+  | 'COMPLETED'
+  | 'INCOMPLETE'
+  | 'CANCELLED'
+  | 'NO_SHOW_CLIENT'
+  | 'NO_SHOW_CAREGIVER'
+  | 'REJECTED';
+
+export type AssignmentMethod =
+  | 'MANUAL'
+  | 'AUTO_MATCH'
+  | 'SELF_ASSIGN'
+  | 'PREFERRED'
+  | 'OVERFLOW';
+
+export interface VisitSearchFilters {
+  query?: string;
+  organizationId?: string;
+  branchId?: string;
+  branchIds?: string[];
+  clientId?: string;
+  caregiverId?: string;
+  status?: VisitStatus[];
+  visitType?: VisitType[];
+  dateFrom?: Date;
+  dateTo?: Date;
+  isUnassigned?: boolean;
+  isUrgent?: boolean;
+}
+
+export const VISIT_STATUS_LABELS: Record<VisitStatus, string> = {
+  DRAFT: 'Draft',
+  SCHEDULED: 'Scheduled',
+  UNASSIGNED: 'Unassigned',
+  ASSIGNED: 'Assigned',
+  CONFIRMED: 'Confirmed',
+  EN_ROUTE: 'En Route',
+  ARRIVED: 'Arrived',
+  IN_PROGRESS: 'In Progress',
+  PAUSED: 'Paused',
+  COMPLETED: 'Completed',
+  INCOMPLETE: 'Incomplete',
+  CANCELLED: 'Cancelled',
+  NO_SHOW_CLIENT: 'No Show (Client)',
+  NO_SHOW_CAREGIVER: 'No Show (Caregiver)',
+  REJECTED: 'Rejected',
+};
+
+export const VISIT_TYPE_LABELS: Record<VisitType, string> = {
+  REGULAR: 'Regular',
+  INITIAL: 'Initial',
+  DISCHARGE: 'Discharge',
+  RESPITE: 'Respite',
+  EMERGENCY: 'Emergency',
+  MAKEUP: 'Makeup',
+  SUPERVISION: 'Supervision',
+  ASSESSMENT: 'Assessment',
+};
+
+export const VISIT_STATUS_COLORS: Record<VisitStatus, string> = {
+  DRAFT: 'gray',
+  SCHEDULED: 'blue',
+  UNASSIGNED: 'yellow',
+  ASSIGNED: 'cyan',
+  CONFIRMED: 'green',
+  EN_ROUTE: 'indigo',
+  ARRIVED: 'purple',
+  IN_PROGRESS: 'blue',
+  PAUSED: 'orange',
+  COMPLETED: 'green',
+  INCOMPLETE: 'yellow',
+  CANCELLED: 'gray',
+  NO_SHOW_CLIENT: 'red',
+  NO_SHOW_CAREGIVER: 'red',
+  REJECTED: 'red',
+};


### PR DESCRIPTION
…isit list page

- Created scheduling-visits vertical in web package
- Implemented VisitList page with realistic empty state
- Added VisitCard component for displaying visit details
- Created useVisits hook for data fetching from API
- Added visit types and status labels
- Integrated with existing /api/visits/my-visits endpoint
- Shows summary cards for upcoming, unassigned, and completed visits
- Supports grid and list view modes
- Displays proper empty state when no visits are scheduled

This addresses issue #5 - 'Coming soon' placeholder for scheduling vertical