### PR TITLE
Fix tasks endpoint permission errors for caregivers

### DIFF
--- a/packages/core/src/permissions/permission-service.ts
+++ b/packages/core/src/permissions/permission-service.ts
@@ -99,7 +99,9 @@ export class PermissionService {
         'schedules:read',
         'visits:update',
         'care-plans:read',
+        'tasks:read',
         'tasks:update',
+        'tasks:complete',
         'notes:create',
       ])
     );


### PR DESCRIPTION
**Root Cause**:
- getUserContext() in care-plan-handlers.ts extracted user context from custom headers instead of using req.user populated by JWT middleware
- This resulted in empty permissions array, causing 403 errors
- CAREGIVER role was missing tasks:read and tasks:complete permissions

**Changes**:
1. Updated getUserContext() to use req.user from JWT token payload
   - Removed header-based extraction
   - Added proper type declaration for req.user
   - Now throws error if req.user is not populated

2. Added missing task permissions to CAREGIVER role:
   - tasks:read - Required for viewing task list
   - tasks:complete - Required for completing tasks

**Testing**:
- All care-plans-tasks tests passing (21 tests)
- All core package tests passing (549 tests)
- Build and lint successful

Fixes #2 - Tasks endpoint 403 errors