### PR TITLE
Fix family portal permission errors

### DIFF
--- a/e2e/utils/helpers.ts
+++ b/e2e/utils/helpers.ts
@@ -47,7 +47,11 @@ export async function login(
       organizationId: 'org-e2e-001',
       branchId: 'branch-e2e-001',
       roles: ['FAMILY_MEMBER'],
-      permissions: ['family-portal:read', 'messages:write'],
+      permissions: [
+        'clients:read', 'visits:read', 'care-plans:read', 'tasks:read', 'schedules:read',
+        'family-portal:view', 'notifications:view', 'messages:view', 'messages:write',
+        'activity-feed:view'
+      ],
     },
   };
 

--- a/packages/core/scripts/seed-demo.ts
+++ b/packages/core/scripts/seed-demo.ts
@@ -140,7 +140,9 @@ const ROLES: RoleDefinition[] = [
     label: 'Family Member',
     roles: ['FAMILY'],
     permissions: [
-      'clients:read', 'visits:read', 'care-plans:read', 'tasks:read', 'schedules:read'
+      'clients:read', 'visits:read', 'care-plans:read', 'tasks:read', 'schedules:read',
+      'family-portal:view', 'notifications:view', 'messages:view', 'messages:write',
+      'activity-feed:view'
     ]
   },
   {


### PR DESCRIPTION
…ly role

This commit fixes 403 Forbidden errors that family members were encountering when trying to access the family portal dashboard and related endpoints.

**Root Cause:**
- Family member users had permissions: `clients:read`, `visits:read`, `care-plans:read`, `tasks:read`, `schedules:read`
- But the family engagement service was checking for: `family-portal:view`, `notifications:view`, `messages:view`, `activity-feed:view`
- This permission mismatch caused all family portal endpoints to return 403 errors

**Changes:**
1. Updated family role permissions in `packages/core/scripts/seed-demo.ts` to include:
   - `family-portal:view` - Access to family portal dashboard
   - `notifications:view` - View notifications
   - `messages:view` - Read messages
   - `messages:write` - Send messages
   - `activity-feed:view` - View activity feed

2. Updated E2E test fixtures in `e2e/utils/helpers.ts` to match production permissions

**Impact:**
- Family members can now successfully access `/api/family-engagement/dashboard/family-member/:id`
- Family portal is now fully functional for family member users
- All 255 state-specific family users (e.g., `family@tx.carecommons.example`) now have correct permissions

**Testing:**
- Verified permissions in database: `family@tx.carecommons.example` now has all required permissions
- Demo seed creates users with updated permissions
- E2E tests will use consistent permission set

Fixes #3 - Family member portal 403 forbidden errors