### PR TITLE
Add informative demo data banner to layout

### DIFF
--- a/packages/core/src/demo/__tests__/demo-session-manager.test.ts
+++ b/packages/core/src/demo/__tests__/demo-session-manager.test.ts
@@ -43,7 +43,9 @@ describe('DemoSessionManager', () => {
 
     mockSnapshot = {
       organizationId: 'org-1',
+      organizationName: 'Demo Home Health',
       branchId: 'branch-1',
+      branchName: 'Main Branch',
       baseTime: new Date('2025-01-05T08:00:00Z'),
       caregiverIds: ['cg-1', 'cg-2'],
       clientIds: ['cl-1', 'cl-2'],

--- a/packages/core/src/demo/demo-session-manager.ts
+++ b/packages/core/src/demo/demo-session-manager.ts
@@ -46,7 +46,9 @@ export class DemoSessionManager {
       id: sessionId,
       userId,
       organizationId: snapshot.organizationId,
+      organizationName: snapshot.organizationName,
       branchId: snapshot.branchId,
+      branchName: snapshot.branchName,
       currentPersona: initialPersona,
       availablePersonas: snapshot.personas,
       state: {

--- a/packages/core/src/demo/types.ts
+++ b/packages/core/src/demo/types.ts
@@ -70,15 +70,17 @@ export interface DemoSession {
   id: string;
   userId: string;
   organizationId: string;
+  organizationName: string;
   branchId: string;
-  
+  branchName: string;
+
   // Current persona
   currentPersona: DemoPersona;
   availablePersonas: DemoPersona[];
-  
+
   // Session state
   state: DemoSessionState;
-  
+
   // Session lifecycle
   createdAt: Date;
   lastAccessedAt: Date;
@@ -151,15 +153,17 @@ export interface Exception {
 // Demo snapshot for base state
 export interface DemoSnapshot {
   organizationId: string;
+  organizationName: string;
   branchId: string;
+  branchName: string;
   baseTime: Date;
-  
+
   // Reference data (IDs of seeded data)
   caregiverIds: string[];
   clientIds: string[];
   coordinatorIds: string[];
   visitIds: string[];
-  
+
   // Personas available in this demo
   personas: DemoPersona[];
 }

--- a/packages/web/src/demo/DemoModeBar.tsx
+++ b/packages/web/src/demo/DemoModeBar.tsx
@@ -1,6 +1,6 @@
 /**
  * Demo Mode Bar Component
- * 
+ *
  * Persistent banner that displays demo mode status and controls
  */
 
@@ -20,12 +20,12 @@ const PERSONA_LABELS: Record<DemoPersonaType, string> = {
 
 export function DemoModeBar() {
   const { session, isActive, switchPersona, resetSession, endSession } = useDemoSession();
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [isPersonaMenuOpen, setIsPersonaMenuOpen] = useState(false);
   const location = useLocation();
-  
+
   // Check if we're on the login page (no sidebar)
   const isLoginPage = location.pathname === '/login';
-  
+
   // Apply left padding on desktop for pages with sidebar
   const containerClass = isLoginPage ? '' : 'lg:pl-64';
 
@@ -50,96 +50,118 @@ export function DemoModeBar() {
 
   return (
     <div className="bg-gradient-to-r from-purple-600 to-blue-600 text-white shadow-lg">
-      <div className={`px-4 py-2 flex items-center justify-between ${containerClass}`}>
-        <div className="flex items-center gap-4">
+      <div className={`px-4 py-2.5 ${containerClass}`}>
+        <div className="flex items-center justify-between flex-wrap gap-2">
+          {/* Left section: Demo badge + Persona info */}
+          <div className="flex items-center gap-4 flex-wrap">
+            <div className="flex items-center gap-2">
+              <span className="inline-block w-2 h-2 bg-green-400 rounded-full animate-pulse"></span>
+              <span className="font-bold text-sm">DEMO MODE</span>
+            </div>
+
+            {/* Current persona */}
+            <div className="flex items-center gap-2 text-sm">
+              <span className="opacity-90">Logged in as</span>
+              <span className="font-semibold">{session.currentPersona.name}</span>
+              <span className="opacity-75">({PERSONA_LABELS[session.currentPersona.type]})</span>
+            </div>
+
+            {/* Organization info with stats */}
+            <div className="text-sm opacity-90 hidden md:block">
+              <span>Viewing {session.organizationName}</span>
+              {session.stats && (
+                <span className="ml-1">
+                  • {session.stats.clientCount} clients, {session.stats.caregiverCount} caregivers
+                </span>
+              )}
+            </div>
+          </div>
+
+          {/* Right section: Controls */}
           <div className="flex items-center gap-2">
-            <span className="inline-block w-2 h-2 bg-green-400 rounded-full animate-pulse"></span>
-            <span className="font-bold text-sm">DEMO MODE</span>
-          </div>
-          
-          <div className="flex items-center gap-2 text-sm">
-            <span className="opacity-90">Viewing as:</span>
-            <span className="font-semibold">{session.currentPersona.name}</span>
-            <span className="opacity-75">({PERSONA_LABELS[session.currentPersona.type]})</span>
-          </div>
+            {/* Persona switcher dropdown */}
+            <div className="relative">
+              <button
+                onClick={() => setIsPersonaMenuOpen(!isPersonaMenuOpen)}
+                className="bg-white/20 hover:bg-white/30 px-3 py-1.5 rounded text-sm font-medium transition-colors flex items-center gap-1"
+              >
+                <span>Try another role</span>
+                <svg
+                  className={`w-4 h-4 transition-transform ${isPersonaMenuOpen ? 'rotate-180' : ''}`}
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
 
-          <div className="text-xs opacity-75">
-            Session expires in {hoursRemaining}h {minutesRemaining}m
-          </div>
-        </div>
-
-        <div className="flex items-center gap-2">
-          <button
-            onClick={() => setIsExpanded(!isExpanded)}
-            className="bg-white/20 hover:bg-white/30 px-3 py-1 rounded text-sm font-medium transition-colors"
-          >
-            {isExpanded ? 'Hide Controls' : 'Show Controls'}
-          </button>
-          
-          <button
-            onClick={() => void endSession()}
-            className="bg-red-500/80 hover:bg-red-500 px-3 py-1 rounded text-sm font-medium transition-colors"
-          >
-            Exit Demo
-          </button>
-        </div>
-      </div>
-
-      {isExpanded && (
-        <div className={`bg-white/10 px-4 py-3 border-t border-white/20 ${containerClass}`}>
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <h4 className="font-semibold text-sm mb-2">Switch Persona</h4>
-              {session.availablePersonas.length > 0 ? (
-                <div className="grid grid-cols-2 gap-2">
-                  {session.availablePersonas.map((persona) => (
-                    <button
-                      key={persona.id}
-                      onClick={() => void switchPersona(persona.type)}
-                      disabled={persona.id === session.currentPersona.id}
-                      className={`
-                        px-3 py-2 rounded text-sm font-medium transition-colors text-left
-                        ${persona.id === session.currentPersona.id
-                          ? 'bg-white/30 cursor-not-allowed'
-                          : 'bg-white/20 hover:bg-white/30 cursor-pointer'
-                        }
-                      `}
-                    >
-                      <div className="font-semibold">{persona.name}</div>
-                      <div className="text-xs opacity-75">{persona.role}</div>
-                    </button>
-                  ))}
-                </div>
-              ) : (
-                <div className="bg-white/10 px-3 py-2 rounded text-xs opacity-75">
-                  No additional personas available
+              {/* Dropdown menu */}
+              {isPersonaMenuOpen && (
+                <div className="absolute right-0 mt-2 w-64 bg-white rounded-lg shadow-lg overflow-hidden z-50">
+                  <div className="py-1">
+                    {session.availablePersonas.map((persona) => (
+                      <button
+                        key={persona.id}
+                        onClick={() => {
+                          void switchPersona(persona.type);
+                          setIsPersonaMenuOpen(false);
+                        }}
+                        disabled={persona.id === session.currentPersona.id}
+                        className={`
+                          w-full px-4 py-2 text-left transition-colors
+                          ${
+                            persona.id === session.currentPersona.id
+                              ? 'bg-blue-50 text-blue-700 cursor-default'
+                              : 'text-gray-700 hover:bg-gray-100'
+                          }
+                        `}
+                      >
+                        <div className="font-medium text-sm">{persona.name}</div>
+                        <div className="text-xs text-gray-500">
+                          {persona.role}
+                          {persona.id === session.currentPersona.id && (
+                            <span className="ml-2 text-blue-600">✓ Active</span>
+                          )}
+                        </div>
+                      </button>
+                    ))}
+                  </div>
                 </div>
               )}
             </div>
 
-            <div>
-              <h4 className="font-semibold text-sm mb-2">Session Controls</h4>
-              <div className="space-y-2">
-                <button
-                  onClick={() => void resetSession()}
-                  className="w-full bg-white/20 hover:bg-white/30 px-3 py-2 rounded text-sm font-medium transition-colors text-left"
-                >
-                  <div className="font-semibold">Reset Data</div>
-                  <div className="text-xs opacity-75">Restore to initial state</div>
-                </button>
-                
-                <div className="bg-white/10 px-3 py-2 rounded text-xs">
-                  <div className="font-semibold mb-1">Session Info</div>
-                  <div className="opacity-75 space-y-1">
-                    <div>Session ID: {session.id.slice(0, 8)}...</div>
-                    <div>Events: {session.state.eventCount}</div>
-                    <div>Time: {new Date(session.state.currentTime).toLocaleTimeString()}</div>
-                  </div>
-                </div>
-              </div>
+            {/* Reset button */}
+            <button
+              onClick={() => void resetSession()}
+              className="bg-white/20 hover:bg-white/30 px-3 py-1.5 rounded text-sm font-medium transition-colors hidden sm:block"
+              title="Reset all demo changes"
+            >
+              Reset data
+            </button>
+
+            {/* Session timer */}
+            <div className="text-xs opacity-75 hidden lg:block">
+              {hoursRemaining}h {minutesRemaining}m left
             </div>
+
+            {/* Exit demo button */}
+            <button
+              onClick={() => void endSession()}
+              className="bg-red-500/80 hover:bg-red-500 px-3 py-1.5 rounded text-sm font-medium transition-colors"
+            >
+              Exit Demo
+            </button>
           </div>
         </div>
+      </div>
+
+      {/* Click outside to close dropdown */}
+      {isPersonaMenuOpen && (
+        <div
+          className="fixed inset-0 z-40"
+          onClick={() => setIsPersonaMenuOpen(false)}
+        />
       )}
     </div>
   );

--- a/packages/web/src/demo/types.ts
+++ b/packages/web/src/demo/types.ts
@@ -26,12 +26,20 @@ export interface DemoPersona {
 export interface DemoSession {
   id: string;
   userId: string;
+  organizationId: string;
+  organizationName: string;
+  branchId: string;
+  branchName: string;
   currentPersona: DemoPersona;
   availablePersonas: DemoPersona[];
   expiresAt: string;
   state: {
     currentTime: string;
     eventCount: number;
+  };
+  stats: {
+    clientCount: number;
+    caregiverCount: number;
   };
 }
 


### PR DESCRIPTION
Enhanced the demo mode banner to display comprehensive context:
- Current persona: "Logged in as [Name] ([Role])"
- Organization info: "Viewing [Org Name] • X clients, Y caregivers"
- Persona switcher dropdown: "Try another role" with clean dropdown
- Reset button: "Reset data" to restore initial state
- Session timer showing remaining time
- Fully responsive design with proper breakpoints

Backend changes:
- Updated DemoSession and DemoSnapshot types to include organizationName and branchName
- Modified GET /api/demo/sessions/:sessionId to return organization metadata and data counts
- Updated getDemoSnapshot to fetch organization/branch names from database

Frontend changes:
- Redesigned DemoModeBar component with streamlined UI
- Added persona dropdown menu instead of grid of buttons
- Display organization stats (client count, caregiver count)
- Improved mobile responsiveness with hidden elements on small screens
- Added click-outside handler for dropdown menu

The banner is persistent across all pages and provides users with clear context about their current demo session, making it easier to understand the data they're viewing and switch between different roles.