### PR TITLE
Fix Discord webhook notification empty message

### DIFF
--- a/.github/workflows/notifications.yml
+++ b/.github/workflows/notifications.yml
@@ -168,51 +168,56 @@ jobs:
           COMMIT_SHA="${{ github.event.workflow_run.head_sha }}"
           SHORT_SHA="${COMMIT_SHA:0:7}"
           
-          curl -H "Content-Type: application/json" \
-            -d '{
-              "embeds": [{
-                "title": "${{ steps.status.outputs.emoji }} CI - ${{ steps.status.outputs.status_text }}",
-                "description": "Node.js 22 CI build on `develop` branch",
-                "color": ${{ steps.status.outputs.color }},
-                "fields": [
-                  {
-                    "name": "Repository",
-                    "value": "${{ github.repository }}",
-                    "inline": true
-                  },
-                  {
-                    "name": "Branch",
-                    "value": "`${{ github.event.workflow_run.head_branch }}`",
-                    "inline": true
-                  },
-                  {
-                    "name": "Commit",
-                    "value": "[`'"$SHORT_SHA"'`](${{ github.event.workflow_run.repository.html_url }}/commit/${{ github.event.workflow_run.head_sha }})",
-                    "inline": true
-                  },
-                  {
-                    "name": "Triggered by",
-                    "value": "${{ github.event.workflow_run.actor.login }}",
-                    "inline": true
-                  },
-                  {
-                    "name": "Status",
-                    "value": "${{ steps.status.outputs.status_text }}",
-                    "inline": true
-                  },
-                  {
-                    "name": "Node Version",
-                    "value": "22.x",
-                    "inline": true
-                  }
-                ],
-                "timestamp": "${{ github.event.workflow_run.updated_at }}",
-                "footer": {
-                  "text": "Care Commons CI"
+          PAYLOAD=$(cat <<EOF
+          {
+            "embeds": [{
+              "title": "${{ steps.status.outputs.emoji }} CI - ${{ steps.status.outputs.status_text }}",
+              "description": "Node.js 22 CI build on \`develop\` branch",
+              "color": ${{ steps.status.outputs.color }},
+              "fields": [
+                {
+                  "name": "Repository",
+                  "value": "${{ github.repository }}",
+                  "inline": true
                 },
-                "url": "${{ github.event.workflow_run.html_url }}"
-              }]
-            }' \
+                {
+                  "name": "Branch",
+                  "value": "\`${{ github.event.workflow_run.head_branch }}\`",
+                  "inline": true
+                },
+                {
+                  "name": "Commit",
+                  "value": "[\`${SHORT_SHA}\`](${{ github.event.workflow_run.repository.html_url }}/commit/${{ github.event.workflow_run.head_sha }})",
+                  "inline": true
+                },
+                {
+                  "name": "Triggered by",
+                  "value": "${{ github.event.workflow_run.actor.login }}",
+                  "inline": true
+                },
+                {
+                  "name": "Status",
+                  "value": "${{ steps.status.outputs.status_text }}",
+                  "inline": true
+                },
+                {
+                  "name": "Node Version",
+                  "value": "22.x",
+                  "inline": true
+                }
+              ],
+              "timestamp": "${{ github.event.workflow_run.updated_at }}",
+              "footer": {
+                "text": "Care Commons CI"
+              },
+              "url": "${{ github.event.workflow_run.html_url }}"
+            }]
+          }
+          EOF
+          )
+          
+          curl -H "Content-Type: application/json" \
+            -d "$PAYLOAD" \
             "${{ env.DISCORD_WEBHOOK_URL }}"
 
       - name: Discord not configured


### PR DESCRIPTION
## Summary

- Fix Discord webhook notifications showing empty messages in the notifications workflow
- The issue was caused by using single-quoted JSON in curl, preventing shell variable expansion

## Technical Details

The Discord notification step was using single quotes around the JSON payload, which prevented GitHub Actions expressions and shell variables (like `$SHORT_SHA`) from being properly expanded. This resulted in Discord receiving malformed or empty messages.

**Changed:**
- Use heredoc (`<<EOF`) to construct the JSON payload in a variable
- Pass the payload variable to curl with proper quoting
- This allows both GitHub Actions expressions (`${{ ... }}`) and shell variables to be properly substituted

## Testing

- Pre-commit checks passed (lint, typecheck, test, build)
- The next CI run on develop will trigger the Discord notification and verify the fix

## Affected Files

- `.github/workflows/notifications.yml` - Discord notification step