### PR TITLE
Fix recursive Notifications workflow triggers

### DIFF
--- a/.github/workflows/notifications.yml
+++ b/.github/workflows/notifications.yml
@@ -6,11 +6,15 @@ on:
     types:
       - completed
 
+concurrency:
+  group: notifications-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
 jobs:
   notify-slack:
     name: Send Slack Notification
     runs-on: ubuntu-latest
-    if: always() && github.event.workflow_run.conclusion != 'skipped'
+    if: always() && github.event.workflow_run.conclusion != 'skipped' && github.event.workflow_run.name != 'Notifications'
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:


### PR DESCRIPTION
## Summary

- Adds concurrency group to prevent duplicate Notification workflow runs for the same workflow_run event
- Adds explicit exclusion filter to prevent Notifications workflow from triggering on itself
- Fixes the cascade of Notification runs observed where a single CI run spawned 8+ separate Notification workflow runs

## Problem

The Notifications workflow was triggering recursively, creating multiple runs for a single CI completion:
- One CI run would trigger 6-10 separate Notification workflow runs
- Each Notification run would complete successfully but unnecessarily consume GitHub Actions minutes
- The workflow_run trigger should have prevented this, but race conditions or GitHub Actions internals caused multiple triggers

## Solution

1. **Concurrency Group**: Added `concurrency` block keyed to `workflow_run.id`
   - Ensures only one Notification run per source workflow completion
   - Prevents duplicate runs even if multiple workflow_run events fire
   
2. **Explicit Exclusion**: Added `github.event.workflow_run.name != 'Notifications'` check
   - Defense-in-depth to prevent self-triggering
   - Complements the existing `workflows: ["CI", "Deploy"]` filter

## Testing

This fix will be validated by:
- Merging to `develop` and observing that only ONE Notification run occurs
- Checking that Discord notifications still work correctly
- Verifying no cascade of duplicate Notification runs