### PR TITLE
Fix route permissions audit to skip webhook endpoints

### DIFF
--- a/scripts/audit-route-permissions.ts
+++ b/scripts/audit-route-permissions.ts
@@ -52,6 +52,9 @@ const PATTERNS = {
   // Health check endpoints
   healthCheck: /\/health/,
 
+  // Webhook endpoints (use signature verification instead of auth)
+  webhookEndpoint: /\/webhook/i,
+
   // Logout endpoints (don't need permission checks beyond authentication)
   logoutEndpoint: /\/logout$/,
 
@@ -98,6 +101,11 @@ function analyzeRouteFile(filePath: string): SecurityIssue[] {
     return issues;
   }
 
+  // Skip webhook route files - they use signature verification instead of auth middleware
+  if (filePath.includes('/webhooks.ts') || filePath.includes('/webhooks.js')) {
+    return issues;
+  }
+
   // Check if file uses authentication middleware
   const hasRequireAuth = PATTERNS.requireAuth.test(content);
   const hasOptionalAuth = PATTERNS.optionalAuth.test(content);
@@ -115,6 +123,11 @@ function analyzeRouteFile(filePath: string): SecurityIssue[] {
 
     // Skip health check and metrics endpoints
     if (PATTERNS.healthCheck.test(routePath)) {
+      continue;
+    }
+
+    // Skip webhook endpoints (they use signature verification)
+    if (PATTERNS.webhookEndpoint.test(routePath) || filePath.includes('/webhooks.ts')) {
       continue;
     }
 


### PR DESCRIPTION
## Summary
- Fixed route permissions audit script to properly handle webhook endpoints

## Problem
The route permissions audit script was incorrectly flagging webhook endpoints (like Stripe webhooks) as security issues for missing authentication middleware.

Webhooks use signature verification instead of traditional authentication:
- Stripe SDK verifies webhook signatures via `verifyWebhookSignature()`
- This is the recommended security pattern for webhooks
- Authentication middleware (requireAuth) is not appropriate for webhooks

## Solution
- Added webhook endpoint pattern recognition (`/webhook/i`)
- Skip webhook route files entirely from the audit
- Files named `webhooks.ts` or `webhooks.js` are excluded

## Testing
- Pre-commit hooks passed
- Verified audit no longer flags `packages/app/src/routes/webhooks.ts`

## Note
Push notifications routes still show HIGH severity issues in audit. These routes DO check `req.userContext?.userId` manually for authentication, but should be refactored to use `requireAuth` middleware for consistency with the rest of the codebase.