### PR TITLE
Fix webhook and metrics routing in Vercel deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -17,6 +17,14 @@
       "destination": "/api"
     },
     {
+      "source": "/metrics",
+      "destination": "/api"
+    },
+    {
+      "source": "/webhooks/:path*",
+      "destination": "/api"
+    },
+    {
       "source": "/(.*)",
       "destination": "/index.html"
     }


### PR DESCRIPTION
## Summary
- Fixed Vercel routing configuration to properly route webhook and metrics endpoints to the serverless API function

## Problem
The  and  routes were not included in  rewrites, causing them to fall through to the SPA static file handler instead of being routed to the serverless API function.

**Symptoms**:
-  returned the SPA HTML (200 OK with React app)
- Stripe webhook events could not be processed
-  endpoint was inaccessible for Prometheus scraping

## Solution
Added rewrite rules in :
-  →  (serverless function)
-  →  (serverless function)

## Technical Details

### Why This Fix Works
1. **Vercel Routing Order**: Rewrites are processed before static file serving
2. **Serverless Function**: The  serverless function handles all API routes including webhooks
3. **CSRF Bypass**: Webhooks are at  (not ), so they correctly bypass CSRF protection which only applies to  paths

### Affected Endpoints
-  - Stripe payment webhook handler
-  - Prometheus metrics endpoint (CPU, memory, request stats)

## Verification
After deployment, webhooks will:
- Accept POST requests with Stripe signature verification
- Process subscription events (created, updated, deleted, etc.)
- Handle payment events (invoice.paid, invoice.payment_failed)
- Return proper HTTP status codes (not HTML)

## Testing
- Pre-commit hooks passed
- Configuration is JSON-valid
- No code changes required (routing fix only)