### PR TITLE
fix: backup workflow tsx command and permissions

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -31,6 +31,9 @@ jobs:
   backup:
     name: Create Database Backup
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     
     steps:
       - name: Checkout code
@@ -78,13 +81,16 @@ jobs:
           MONTHLY_RETENTION_MONTHS: 12
         run: |
           BACKUP_TYPE="${{ github.event.inputs.backup_type || 'both' }}"
-          tsx scripts/backup-neon.ts --type "$BACKUP_TYPE"
+          npx tsx scripts/backup-neon.ts --type "$BACKUP_TYPE"
       
       - name: Verify backup
         if: github.event.inputs.verify != 'false'
         env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          NEON_PROJECT_ID: ${{ secrets.NEON_PROJECT_ID }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
           BACKUP_DIR: /tmp/backups
-        run: tsx scripts/backup-neon.ts --verify
+        run: npx tsx scripts/backup-neon.ts --verify
       
       - name: Upload backup artifacts (for debugging)
         if: failure()


### PR DESCRIPTION
## Summary
- Fix `tsx: command not found` error by using `npx tsx` instead of bare `tsx`
- Add missing environment variables (NEON_API_KEY, NEON_PROJECT_ID, DATABASE_URL) to the verify step
- Add `permissions` block for issue creation on workflow failure

Fixes #421