### PR TITLE
fix: resolve PostgreSQL version mismatch in backup workflow

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -61,8 +61,17 @@ jobs:
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo apt-get update
           sudo apt-get install -y postgresql-client-17
-          # Ensure pg17 is used instead of default pg16
+
+          # Verify installation
+          dpkg -l | grep postgresql-client
+
+          # Set PostgreSQL 17 bin directory as highest priority in PATH
           echo "/usr/lib/postgresql/17/bin" >> $GITHUB_PATH
+          export PATH="/usr/lib/postgresql/17/bin:$PATH"
+
+          # Verify pg_dump version
+          which pg_dump
+          pg_dump --version
       
       - name: Install Neon CLI
         run: |
@@ -89,7 +98,12 @@ jobs:
           S3_BACKUP_BUCKET: ${{ secrets.S3_BACKUP_BUCKET }}
           BACKUP_RETENTION_DAYS: 30
           MONTHLY_RETENTION_MONTHS: 12
+          PATH: /usr/lib/postgresql/17/bin:${{ env.PATH }}
         run: |
+          # Verify we're using the correct pg_dump version
+          echo "Using pg_dump: $(which pg_dump)"
+          pg_dump --version
+
           BACKUP_TYPE="${{ github.event.inputs.backup_type || 'both' }}"
           npx tsx scripts/backup-neon.ts --type "$BACKUP_TYPE"
       
@@ -100,6 +114,7 @@ jobs:
           NEON_PROJECT_ID: ${{ secrets.NEON_PROJECT_ID }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           BACKUP_DIR: /tmp/backups
+          PATH: /usr/lib/postgresql/17/bin:${{ env.PATH }}
         run: npx tsx scripts/backup-neon.ts --verify
       
       - name: Upload backup artifacts (for debugging)


### PR DESCRIPTION
## Problem

Database backups failing with PostgreSQL version mismatch:
- **Server:** PostgreSQL 17.6  
- **Workflow:** pg_dump 16.10
- **Error:** `aborting because of server version mismatch`

## Solution

- Explicitly set `PATH` to use PostgreSQL 17 binaries in backup steps
- Added version verification before running backup
- Ensures pg_dump 17 is used instead of system default 16

## Changes

- Updated `.github/workflows/backup.yml`:
  - Added PATH environment variable to backup and verify steps
  - Added version verification logging
  - Improved PostgreSQL 17 installation verification

## Testing

- ✅ Pre-commit checks passed (lint, typecheck, test, build)
- 🔄 Manual workflow run required to verify backup fix

## Related

Fixes #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)