### PR TITLE
feat: Add webhook support for external integrations

### DIFF
--- a/packages/core/migrations/20251207120000_create_webhooks_table.ts
+++ b/packages/core/migrations/20251207120000_create_webhooks_table.ts
@@ -1,0 +1,162 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  // Create webhooks table for webhook configurations
+  await knex.schema.createTable('webhooks', (table) => {
+    // Primary key
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+
+    // Organization reference
+    table
+      .uuid('organization_id')
+      .notNullable()
+      .references('id')
+      .inTable('organizations')
+      .onDelete('CASCADE');
+
+    // Webhook configuration
+    table.string('name', 100).notNullable();
+    table.text('url').notNullable();
+    table.text('secret').notNullable(); // HMAC signing secret
+    table.jsonb('events').notNullable(); // Array of event types to subscribe to
+    table.text('description');
+    table.jsonb('headers'); // Custom headers to include with webhook requests
+
+    // Status
+    table
+      .enum('status', ['active', 'inactive', 'suspended'], {
+        useNative: true,
+        enumName: 'webhook_status',
+      })
+      .notNullable()
+      .defaultTo('active');
+
+    // Retry policy
+    table.jsonb('retry_policy').notNullable().defaultTo(
+      JSON.stringify({
+        maxRetries: 3,
+        retryDelayMs: 5000,
+        exponentialBackoff: true,
+      })
+    );
+
+    // Statistics
+    table.integer('success_count').notNullable().defaultTo(0);
+    table.integer('failure_count').notNullable().defaultTo(0);
+    table.timestamp('last_triggered_at');
+
+    // Soft delete
+    table.boolean('is_deleted').notNullable().defaultTo(false);
+
+    // Audit fields
+    table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
+    table.uuid('created_by').notNullable().references('id').inTable('users');
+    table.timestamp('updated_at').notNullable().defaultTo(knex.fn.now());
+  });
+
+  // Create webhook_deliveries table for delivery tracking
+  await knex.schema.createTable('webhook_deliveries', (table) => {
+    // Primary key
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+
+    // Webhook reference
+    table
+      .uuid('webhook_id')
+      .notNullable()
+      .references('id')
+      .inTable('webhooks')
+      .onDelete('CASCADE');
+
+    // Event information
+    table.string('event_type', 100).notNullable();
+    table.uuid('event_id').notNullable(); // Unique ID for the event
+    table.jsonb('payload').notNullable(); // The webhook payload
+
+    // Delivery status
+    table
+      .enum('status', ['pending', 'delivered', 'failed', 'retrying'], {
+        useNative: true,
+        enumName: 'webhook_delivery_status',
+      })
+      .notNullable()
+      .defaultTo('pending');
+
+    // Retry tracking
+    table.integer('attempts').notNullable().defaultTo(0);
+    table.timestamp('last_attempt_at');
+    table.timestamp('next_retry_at');
+
+    // Response information
+    table.integer('response_status');
+    table.text('response_body');
+    table.integer('response_time_ms');
+    table.text('error_message');
+
+    // Timestamps
+    table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
+    table.timestamp('delivered_at');
+  });
+
+  // Indexes for performance
+  await knex.raw(
+    'CREATE INDEX idx_webhooks_org_id ON webhooks(organization_id) WHERE is_deleted = false'
+  );
+  await knex.raw(
+    'CREATE INDEX idx_webhooks_status ON webhooks(status) WHERE is_deleted = false'
+  );
+  await knex.raw(
+    'CREATE INDEX idx_webhook_deliveries_webhook_id ON webhook_deliveries(webhook_id)'
+  );
+  await knex.raw(
+    'CREATE INDEX idx_webhook_deliveries_status ON webhook_deliveries(status)'
+  );
+  await knex.raw(
+    'CREATE INDEX idx_webhook_deliveries_event_id ON webhook_deliveries(event_id)'
+  );
+  await knex.raw(
+    'CREATE INDEX idx_webhook_deliveries_next_retry ON webhook_deliveries(next_retry_at) WHERE status = \'retrying\''
+  );
+  await knex.raw(
+    'CREATE INDEX idx_webhook_deliveries_created_at ON webhook_deliveries(created_at DESC)'
+  );
+
+  // GIN index for events array search
+  await knex.raw(
+    'CREATE INDEX idx_webhooks_events ON webhooks USING GIN (events)'
+  );
+
+  // Trigger to automatically update updated_at
+  await knex.raw(`
+    CREATE TRIGGER update_webhooks_updated_at
+      BEFORE UPDATE ON webhooks
+      FOR EACH ROW
+      EXECUTE FUNCTION update_updated_at_column()
+  `);
+
+  // Comments for documentation
+  await knex.raw(
+    "COMMENT ON TABLE webhooks IS 'Webhook configurations for external integrations'"
+  );
+  await knex.raw(
+    "COMMENT ON COLUMN webhooks.secret IS 'HMAC secret for signing webhook payloads'"
+  );
+  await knex.raw(
+    "COMMENT ON COLUMN webhooks.events IS 'JSON array of event types this webhook subscribes to'"
+  );
+  await knex.raw(
+    "COMMENT ON TABLE webhook_deliveries IS 'Delivery history and status for webhook events'"
+  );
+  await knex.raw(
+    "COMMENT ON COLUMN webhook_deliveries.event_id IS 'Unique identifier for the triggering event'"
+  );
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(
+    'DROP TRIGGER IF EXISTS update_webhooks_updated_at ON webhooks'
+  );
+  await knex.schema.dropTableIfExists('webhook_deliveries');
+  await knex.schema.dropTableIfExists('webhooks');
+  await knex.raw('DROP TYPE IF EXISTS webhook_delivery_status');
+  await knex.raw('DROP TYPE IF EXISTS webhook_status');
+}

--- a/verticals/integrations/eslint.config.js
+++ b/verticals/integrations/eslint.config.js
@@ -1,0 +1,116 @@
+import js from '@eslint/js'
+import typescript from '@typescript-eslint/eslint-plugin'
+import typescriptParser from '@typescript-eslint/parser'
+import sonarjs from 'eslint-plugin-sonarjs'
+import unicorn from 'eslint-plugin-unicorn'
+import promise from 'eslint-plugin-promise'
+export default [
+  js.configs.recommended,
+  sonarjs.configs.recommended,
+  promise.configs['flat/recommended'],
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parser: typescriptParser,
+      parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: 'module',
+        project: './tsconfig.eslint.json',
+      },
+      globals: {
+        // Node.js globals
+        console: 'readonly',
+        process: 'readonly',
+        __dirname: 'readonly',
+        require: 'readonly',
+        exports: 'readonly',
+        module: 'readonly',
+        Buffer: 'readonly',
+        setTimeout: 'readonly',
+        setInterval: 'readonly',
+        clearTimeout: 'readonly',
+        clearInterval: 'readonly',
+        global: 'readonly',
+        fetch: 'readonly',
+        AbortSignal: 'readonly',
+        AbortController: 'readonly',
+        // Vitest globals (when using globals: true)
+        describe: 'readonly',
+        it: 'readonly',
+        test: 'readonly',
+        expect: 'readonly',
+        beforeEach: 'readonly',
+        afterEach: 'readonly',
+        beforeAll: 'readonly',
+        afterAll: 'readonly',
+        vi: 'readonly',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': typescript,
+      unicorn,
+    },
+    rules: {
+      ...typescript.configs.recommended.rules,
+      // TypeScript strict rules
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
+      '@typescript-eslint/no-require-imports': 'error',
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-misused-promises': 'error',
+      '@typescript-eslint/await-thenable': 'error',
+      '@typescript-eslint/no-unnecessary-condition': 'off',
+      '@typescript-eslint/prefer-nullish-coalescing': 'off',
+      '@typescript-eslint/prefer-optional-chain': 'off',
+      '@typescript-eslint/strict-boolean-expressions': 'off',
+      // Sonarjs rules
+      'sonarjs/cognitive-complexity': ['error', 70],
+      'sonarjs/no-commented-code': 'off',
+      'sonarjs/deprecation': 'off',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      // Unicorn rules
+      'unicorn/prevent-abbreviations': 'off',
+      'unicorn/filename-case': ['error', { case: 'kebabCase' }],
+      'unicorn/no-null': 'off',
+      'unicorn/no-useless-undefined': 'off',
+      'unicorn/prefer-string-slice': 'off',
+      'sonarjs/pseudo-random': 'off',
+      'unicorn/better-regex': 'off',
+      'sonarjs/concise-regex': 'off',
+      'sonarjs/no-duplicate-string': 'off',
+      'sonarjs/no-nested-functions': 'off',
+      'sonarjs/no-nested-conditional': 'off',
+      'sonarjs/different-types-comparison': 'off',
+      'unicorn/prefer-module': 'off',
+      'unicorn/prefer-node-protocol': 'off',
+      'unicorn/prefer-top-level-await': 'off',
+      'unicorn/no-array-for-each': 'off',
+      'unicorn/explicit-length-check': 'off',
+      'unicorn/no-for-loop': 'off',
+    },
+  },
+  {
+    files: ['**/__tests__/**/*.ts', '**/*.test.ts'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+    },
+  },
+  {
+    ignores: [
+      'dist/',
+      '*.js',
+      '*.d.ts',
+      '*.js.map',
+      '*.d.ts.map',
+      'eslint.config.js',
+      'vitest.config.js',
+    ],
+  },
+]

--- a/verticals/integrations/package.json
+++ b/verticals/integrations/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@folkcare/integrations",
+  "version": "0.1.0",
+  "description": "Webhook and integration support for Folk Care",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "engines": {
+    "node": "22.x"
+  },
+  "scripts": {
+    "build": "tsc --composite false && tsc-alias -p tsconfig.json",
+    "dev": "tsc --watch",
+    "lint": "eslint . --ext .ts,.tsx --max-warnings 10",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@folkcare/core": "^0.1.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.39.1",
+    "@types/express": "^5.0.5",
+    "@types/node": "^22.10.2",
+    "@typescript-eslint/eslint-plugin": "^8.46.4",
+    "@typescript-eslint/parser": "^8.46.4",
+    "eslint": "^9.39.1",
+    "eslint-plugin-promise": "^7.2.1",
+    "eslint-plugin-sonarjs": "^3.0.5",
+    "eslint-plugin-unicorn": "^62.0.0",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
+  },
+  "peerDependencies": {
+    "express": "^4.17.0 || ^5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "express": {
+      "optional": true
+    }
+  }
+}

--- a/verticals/integrations/src/index.ts
+++ b/verticals/integrations/src/index.ts
@@ -1,0 +1,8 @@
+// Types
+export * from './types/webhook.js';
+
+// Services
+export { WebhookService } from './services/webhook-service.js';
+
+// Routes
+export { createWebhookRoutes } from './routes/webhook-routes.js';

--- a/verticals/integrations/src/routes/webhook-routes.ts
+++ b/verticals/integrations/src/routes/webhook-routes.ts
@@ -1,0 +1,309 @@
+import type { Router, Request, Response, NextFunction } from 'express';
+import type { WebhookService } from '../services/webhook-service.js';
+import { CreateWebhookSchema, UpdateWebhookSchema } from '../types/webhook.js';
+
+interface AuthenticatedRequest extends Request {
+  user?: {
+    id: string;
+    organizationId: string;
+    role: string;
+  };
+}
+
+type AsyncHandler = (
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction
+) => Promise<void>;
+
+// Wrapper for async route handlers
+const asyncHandler =
+  (fn: AsyncHandler) =>
+  (req: Request, res: Response, next: NextFunction): void => {
+    fn(req as AuthenticatedRequest, res, next).catch((error: unknown) => {
+      next(error);
+    });
+  };
+
+export function createWebhookRoutes(
+  router: Router,
+  webhookService: WebhookService
+): Router {
+  // List webhooks
+  router.get(
+    '/webhooks',
+    asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
+      const organizationId = req.user?.organizationId;
+      if (!organizationId) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+
+      const status = req.query.status as string | undefined;
+      const event = req.query.event as string | undefined;
+
+      const webhooks = await webhookService.listWebhooks(organizationId, {
+        status,
+        event,
+      });
+
+      // Don't expose secrets in list response
+      const sanitizedWebhooks = webhooks.map((w) => ({
+        ...w,
+        secret: undefined,
+      }));
+
+      res.json({ webhooks: sanitizedWebhooks });
+    })
+  );
+
+  // Create webhook
+  router.post(
+    '/webhooks',
+    asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
+      const organizationId = req.user?.organizationId;
+      const userId = req.user?.id;
+      if (!organizationId || !userId) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+
+      const parseResult = CreateWebhookSchema.safeParse(req.body);
+      if (!parseResult.success) {
+        res.status(400).json({
+          error: 'Validation failed',
+          details: parseResult.error.issues,
+        });
+        return;
+      }
+
+      const webhook = await webhookService.createWebhook(
+        organizationId,
+        userId,
+        parseResult.data
+      );
+
+      // Return full webhook including secret on creation
+      res.status(201).json({ webhook });
+    })
+  );
+
+  // Get webhook by ID
+  router.get(
+    '/webhooks/:id',
+    asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
+      const organizationId = req.user?.organizationId;
+      if (!organizationId) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+      const webhookId = req.params.id as string;
+
+      const webhook = await webhookService.getWebhookById(
+        webhookId,
+        organizationId
+      );
+
+      if (!webhook) {
+        res.status(404).json({ error: 'Webhook not found' });
+        return;
+      }
+
+      // Don't expose secret in get response
+      res.json({ webhook: { ...webhook, secret: undefined } });
+    })
+  );
+
+  // Update webhook
+  router.patch(
+    '/webhooks/:id',
+    asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
+      const organizationId = req.user?.organizationId;
+      if (!organizationId) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+      const webhookId = req.params.id as string;
+
+      const parseResult = UpdateWebhookSchema.safeParse(req.body);
+      if (!parseResult.success) {
+        res.status(400).json({
+          error: 'Validation failed',
+          details: parseResult.error.issues,
+        });
+        return;
+      }
+
+      const webhook = await webhookService.updateWebhook(
+        webhookId,
+        organizationId,
+        parseResult.data
+      );
+
+      if (!webhook) {
+        res.status(404).json({ error: 'Webhook not found' });
+        return;
+      }
+
+      res.json({ webhook: { ...webhook, secret: undefined } });
+    })
+  );
+
+  // Delete webhook
+  router.delete(
+    '/webhooks/:id',
+    asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
+      const organizationId = req.user?.organizationId;
+      if (!organizationId) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+      const webhookId = req.params.id as string;
+
+      const deleted = await webhookService.deleteWebhook(
+        webhookId,
+        organizationId
+      );
+
+      if (!deleted) {
+        res.status(404).json({ error: 'Webhook not found' });
+        return;
+      }
+
+      res.status(204).send();
+    })
+  );
+
+  // Regenerate webhook secret
+  router.post(
+    '/webhooks/:id/regenerate-secret',
+    asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
+      const organizationId = req.user?.organizationId;
+      if (!organizationId) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+      const webhookId = req.params.id as string;
+
+      const secret = await webhookService.regenerateSecret(
+        webhookId,
+        organizationId
+      );
+
+      if (!secret) {
+        res.status(404).json({ error: 'Webhook not found' });
+        return;
+      }
+
+      res.json({ secret });
+    })
+  );
+
+  // Get webhook delivery history
+  router.get(
+    '/webhooks/:id/deliveries',
+    asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
+      const organizationId = req.user?.organizationId;
+      if (!organizationId) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+      const webhookId = req.params.id as string;
+
+      const limit = req.query.limit ? Number(req.query.limit) : 50;
+      const offset = req.query.offset ? Number(req.query.offset) : 0;
+      const status = req.query.status as string | undefined;
+
+      const deliveries = await webhookService.getDeliveryHistory(
+        webhookId,
+        organizationId,
+        {
+          limit,
+          offset,
+          status: status as 'pending' | 'delivered' | 'failed' | 'retrying' | undefined,
+        }
+      );
+
+      res.json({ deliveries });
+    })
+  );
+
+  // Get specific delivery
+  router.get(
+    '/webhooks/:webhookId/deliveries/:deliveryId',
+    asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
+      const organizationId = req.user?.organizationId;
+      if (!organizationId) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+      const deliveryId = req.params.deliveryId as string;
+
+      const delivery = await webhookService.getDeliveryById(
+        deliveryId,
+        organizationId
+      );
+
+      if (!delivery) {
+        res.status(404).json({ error: 'Delivery not found' });
+        return;
+      }
+
+      res.json({ delivery });
+    })
+  );
+
+  // Retry failed delivery
+  router.post(
+    '/webhooks/:webhookId/deliveries/:deliveryId/retry',
+    asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
+      const organizationId = req.user?.organizationId;
+      if (!organizationId) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+      const deliveryId = req.params.deliveryId as string;
+
+      const success = await webhookService.retryDelivery(
+        deliveryId,
+        organizationId
+      );
+
+      if (!success) {
+        res.status(400).json({
+          error: 'Cannot retry delivery. It may not exist or is already in progress.',
+        });
+        return;
+      }
+
+      res.json({ message: 'Retry initiated' });
+    })
+  );
+
+  // Get webhook statistics
+  router.get(
+    '/webhooks/:id/stats',
+    asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
+      const organizationId = req.user?.organizationId;
+      if (!organizationId) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+      const webhookId = req.params.id as string;
+
+      const stats = await webhookService.getWebhookStats(
+        webhookId,
+        organizationId
+      );
+
+      if (!stats) {
+        res.status(404).json({ error: 'Webhook not found' });
+        return;
+      }
+
+      res.json({ stats });
+    })
+  );
+
+  return router;
+}

--- a/verticals/integrations/src/services/webhook-service.ts
+++ b/verticals/integrations/src/services/webhook-service.ts
@@ -1,0 +1,605 @@
+import crypto from 'node:crypto';
+import type { Knex } from 'knex';
+import type {
+  Webhook,
+  WebhookDelivery,
+  WebhookEventPayload,
+  WebhookStats,
+  CreateWebhookInput,
+  UpdateWebhookInput,
+  DeliveryStatus,
+} from '../types/webhook.js';
+
+interface WebhookServiceDependencies {
+  db: Knex;
+}
+
+export class WebhookService {
+  private db: Knex;
+
+  constructor({ db }: WebhookServiceDependencies) {
+    this.db = db;
+  }
+
+  // ============================================================================
+  // Webhook CRUD Operations
+  // ============================================================================
+
+  async createWebhook(
+    organizationId: string,
+    userId: string,
+    input: CreateWebhookInput
+  ): Promise<Webhook> {
+    const secret = this.generateSecret();
+    const id = crypto.randomUUID();
+
+    const webhook: Partial<Webhook> = {
+      id,
+      organizationId,
+      name: input.name,
+      url: input.url,
+      secret,
+      events: input.events,
+      description: input.description,
+      headers: input.headers,
+      status: 'active',
+      retryPolicy: input.retryPolicy ?? {
+        maxRetries: 3,
+        retryDelayMs: 5000,
+        exponentialBackoff: true,
+      },
+      createdBy: userId,
+      successCount: 0,
+      failureCount: 0,
+    };
+
+    await this.db('webhooks').insert({
+      id: webhook.id,
+      organization_id: webhook.organizationId,
+      name: webhook.name,
+      url: webhook.url,
+      secret: webhook.secret,
+      events: JSON.stringify(webhook.events),
+      description: webhook.description,
+      headers: webhook.headers ? JSON.stringify(webhook.headers) : null,
+      status: webhook.status,
+      retry_policy: JSON.stringify(webhook.retryPolicy),
+      created_by: webhook.createdBy,
+      success_count: webhook.successCount,
+      failure_count: webhook.failureCount,
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+
+    return this.getWebhookById(id, organizationId) as Promise<Webhook>;
+  }
+
+  async getWebhookById(
+    id: string,
+    organizationId: string
+  ): Promise<Webhook | null> {
+    const row = await this.db('webhooks')
+      .where({ id, organization_id: organizationId, is_deleted: false })
+      .first();
+
+    return row ? this.mapRowToWebhook(row) : null;
+  }
+
+  async listWebhooks(
+    organizationId: string,
+    options?: { status?: string; event?: string }
+  ): Promise<Webhook[]> {
+    let query = this.db('webhooks')
+      .where({ organization_id: organizationId, is_deleted: false })
+      .orderBy('created_at', 'desc');
+
+    if (options?.status) {
+      query = query.where('status', options.status);
+    }
+
+    const rows = await query;
+
+    // Filter by event if specified
+    let webhooks = rows.map((row: Record<string, unknown>) => this.mapRowToWebhook(row));
+    if (options?.event) {
+      webhooks = webhooks.filter((w: Webhook) => w.events.includes(options.event!));
+    }
+
+    return webhooks;
+  }
+
+  async updateWebhook(
+    id: string,
+    organizationId: string,
+    input: UpdateWebhookInput
+  ): Promise<Webhook | null> {
+    const updates: Record<string, unknown> = { updated_at: new Date() };
+
+    if (input.name !== undefined) updates.name = input.name;
+    if (input.url !== undefined) updates.url = input.url;
+    if (input.events !== undefined) updates.events = JSON.stringify(input.events);
+    if (input.description !== undefined) updates.description = input.description;
+    if (input.headers !== undefined)
+      updates.headers = JSON.stringify(input.headers);
+    if (input.status !== undefined) updates.status = input.status;
+    if (input.retryPolicy !== undefined)
+      updates.retry_policy = JSON.stringify(input.retryPolicy);
+
+    await this.db('webhooks')
+      .where({ id, organization_id: organizationId, is_deleted: false })
+      .update(updates);
+
+    return this.getWebhookById(id, organizationId);
+  }
+
+  async deleteWebhook(id: string, organizationId: string): Promise<boolean> {
+    const result = await this.db('webhooks')
+      .where({ id, organization_id: organizationId })
+      .update({ is_deleted: true, updated_at: new Date() });
+
+    return result > 0;
+  }
+
+  async regenerateSecret(
+    id: string,
+    organizationId: string
+  ): Promise<string | null> {
+    const newSecret = this.generateSecret();
+
+    const result = await this.db('webhooks')
+      .where({ id, organization_id: organizationId, is_deleted: false })
+      .update({ secret: newSecret, updated_at: new Date() });
+
+    return result > 0 ? newSecret : null;
+  }
+
+  // ============================================================================
+  // Event Triggering
+  // ============================================================================
+
+  async triggerEvent<T extends Record<string, unknown>>(
+    organizationId: string,
+    eventType: string,
+    data: T,
+    metadata?: { triggeredBy?: string; correlationId?: string; source?: string }
+  ): Promise<string[]> {
+    // Find all active webhooks subscribed to this event
+    const webhooks = await this.listWebhooks(organizationId, {
+      status: 'active',
+      event: eventType,
+    });
+
+    if (webhooks.length === 0) {
+      return [];
+    }
+
+    const eventId = crypto.randomUUID();
+    const deliveryIds: string[] = [];
+
+    // Create delivery records for each webhook
+    for (const webhook of webhooks) {
+      const payload: WebhookEventPayload = {
+        id: eventId,
+        type: eventType as WebhookEventPayload['type'],
+        timestamp: new Date().toISOString(),
+        organizationId,
+        data,
+        metadata,
+      };
+
+      const deliveryId = await this.createDelivery(webhook.id, eventType, eventId, payload);
+      deliveryIds.push(deliveryId);
+
+      // Queue for async delivery (in production, use a job queue)
+      // For now, we'll deliver synchronously but not block on response
+      this.deliverWebhook(webhook, deliveryId, payload).catch((error) => {
+        console.error(`Failed to deliver webhook ${webhook.id}:`, error);
+      });
+    }
+
+    return deliveryIds;
+  }
+
+  // ============================================================================
+  // Webhook Delivery
+  // ============================================================================
+
+  private async createDelivery(
+    webhookId: string,
+    eventType: string,
+    eventId: string,
+    payload: WebhookEventPayload
+  ): Promise<string> {
+    const id = crypto.randomUUID();
+
+    await this.db('webhook_deliveries').insert({
+      id,
+      webhook_id: webhookId,
+      event_type: eventType,
+      event_id: eventId,
+      payload: JSON.stringify(payload),
+      status: 'pending',
+      attempts: 0,
+      created_at: new Date(),
+    });
+
+    return id;
+  }
+
+  private async deliverWebhook(
+    webhook: Webhook,
+    deliveryId: string,
+    payload: WebhookEventPayload
+  ): Promise<void> {
+    const startTime = Date.now();
+    let attempts = 1;
+    let lastError: Error | null = null;
+
+    const maxRetries = webhook.retryPolicy.maxRetries;
+    const baseDelay = webhook.retryPolicy.retryDelayMs;
+    const useExponentialBackoff = webhook.retryPolicy.exponentialBackoff;
+
+    while (attempts <= maxRetries + 1) {
+      try {
+        // Update delivery status to retrying if not first attempt
+        if (attempts > 1) {
+          await this.updateDeliveryStatus(deliveryId, 'retrying', {
+            attempts,
+            lastAttemptAt: new Date(),
+          });
+        }
+
+        const signature = this.signPayload(payload, webhook.secret);
+        const headers: Record<string, string> = {
+          'Content-Type': 'application/json',
+          'X-Webhook-Signature': signature.signature,
+          'X-Webhook-Timestamp': signature.timestamp.toString(),
+          'X-Webhook-Event': payload.type,
+          'X-Webhook-Delivery-Id': deliveryId,
+          ...webhook.headers,
+        };
+
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), 30000);
+
+        const fetchOptions = {
+          method: 'POST',
+          headers,
+          body: JSON.stringify(payload),
+          signal: controller.signal,
+        };
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const response = await fetch(webhook.url, fetchOptions as any);
+
+        clearTimeout(timeoutId);
+
+        const responseTimeMs = Date.now() - startTime;
+        const responseBody = await response.text();
+
+        if (response.ok) {
+          // Success!
+          await this.updateDeliveryStatus(deliveryId, 'delivered', {
+            attempts,
+            responseStatus: response.status,
+            responseBody: responseBody.slice(0, 1000), // Truncate long responses
+            responseTimeMs,
+            deliveredAt: new Date(),
+            lastAttemptAt: new Date(),
+          });
+
+          // Update webhook success count
+          await this.incrementWebhookCounter(webhook.id, 'success');
+          return;
+        }
+
+        // Non-2xx response - treat as failure
+        lastError = new Error(`HTTP ${response.status}: ${responseBody}`);
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+      }
+
+      // Should we retry?
+      if (attempts <= maxRetries) {
+        const delay = useExponentialBackoff
+          ? baseDelay * Math.pow(2, attempts - 1)
+          : baseDelay;
+
+        await this.updateDeliveryStatus(deliveryId, 'retrying', {
+          attempts,
+          nextRetryAt: new Date(Date.now() + delay),
+          errorMessage: lastError?.message,
+          lastAttemptAt: new Date(),
+        });
+
+        await this.sleep(delay);
+        attempts++;
+      } else {
+        break;
+      }
+    }
+
+    // All retries exhausted - mark as failed
+    await this.updateDeliveryStatus(deliveryId, 'failed', {
+      attempts,
+      errorMessage: lastError?.message,
+      responseTimeMs: Date.now() - startTime,
+      lastAttemptAt: new Date(),
+    });
+
+    // Update webhook failure count
+    await this.incrementWebhookCounter(webhook.id, 'failure');
+  }
+
+  private async updateDeliveryStatus(
+    deliveryId: string,
+    status: DeliveryStatus,
+    updates: Partial<{
+      attempts: number;
+      lastAttemptAt: Date;
+      nextRetryAt: Date;
+      responseStatus: number;
+      responseBody: string;
+      responseTimeMs: number;
+      errorMessage: string;
+      deliveredAt: Date;
+    }>
+  ): Promise<void> {
+    const dbUpdates: Record<string, unknown> = { status };
+
+    if (updates.attempts !== undefined) dbUpdates.attempts = updates.attempts;
+    if (updates.lastAttemptAt) dbUpdates.last_attempt_at = updates.lastAttemptAt;
+    if (updates.nextRetryAt) dbUpdates.next_retry_at = updates.nextRetryAt;
+    if (updates.responseStatus !== undefined)
+      dbUpdates.response_status = updates.responseStatus;
+    if (updates.responseBody !== undefined)
+      dbUpdates.response_body = updates.responseBody;
+    if (updates.responseTimeMs !== undefined)
+      dbUpdates.response_time_ms = updates.responseTimeMs;
+    if (updates.errorMessage !== undefined)
+      dbUpdates.error_message = updates.errorMessage;
+    if (updates.deliveredAt) dbUpdates.delivered_at = updates.deliveredAt;
+
+    await this.db('webhook_deliveries').where({ id: deliveryId }).update(dbUpdates);
+  }
+
+  private async incrementWebhookCounter(
+    webhookId: string,
+    type: 'success' | 'failure'
+  ): Promise<void> {
+    const column = type === 'success' ? 'success_count' : 'failure_count';
+    await this.db('webhooks')
+      .where({ id: webhookId })
+      .increment(column, 1)
+      .update({ last_triggered_at: new Date() });
+  }
+
+  // ============================================================================
+  // Delivery History
+  // ============================================================================
+
+  async getDeliveryHistory(
+    webhookId: string,
+    organizationId: string,
+    options?: { limit?: number; offset?: number; status?: DeliveryStatus }
+  ): Promise<WebhookDelivery[]> {
+    // Verify webhook belongs to organization
+    const webhook = await this.getWebhookById(webhookId, organizationId);
+    if (!webhook) {
+      return [];
+    }
+
+    let query = this.db('webhook_deliveries')
+      .where({ webhook_id: webhookId })
+      .orderBy('created_at', 'desc')
+      .limit(options?.limit ?? 50)
+      .offset(options?.offset ?? 0);
+
+    if (options?.status) {
+      query = query.where('status', options.status);
+    }
+
+    const rows = await query;
+    return rows.map((row: Record<string, unknown>) => this.mapRowToDelivery(row));
+  }
+
+  async getDeliveryById(
+    deliveryId: string,
+    organizationId: string
+  ): Promise<WebhookDelivery | null> {
+    const row = await this.db('webhook_deliveries as wd')
+      .join('webhooks as w', 'wd.webhook_id', 'w.id')
+      .where({ 'wd.id': deliveryId, 'w.organization_id': organizationId })
+      .select('wd.*')
+      .first();
+
+    return row ? this.mapRowToDelivery(row) : null;
+  }
+
+  async retryDelivery(
+    deliveryId: string,
+    organizationId: string
+  ): Promise<boolean> {
+    const delivery = await this.getDeliveryById(deliveryId, organizationId);
+    if (!delivery || delivery.status === 'pending' || delivery.status === 'retrying') {
+      return false;
+    }
+
+    const webhook = await this.db('webhooks')
+      .where({ id: delivery.webhookId, organization_id: organizationId, is_deleted: false })
+      .first();
+
+    if (!webhook) {
+      return false;
+    }
+
+    // Reset delivery status and re-deliver
+    await this.updateDeliveryStatus(deliveryId, 'pending', {});
+
+    const webhookObj = this.mapRowToWebhook(webhook);
+    this.deliverWebhook(
+      webhookObj,
+      deliveryId,
+      delivery.payload as unknown as WebhookEventPayload
+    ).catch((error) => {
+      console.error(`Failed to retry delivery ${deliveryId}:`, error);
+    });
+
+    return true;
+  }
+
+  // ============================================================================
+  // Statistics
+  // ============================================================================
+
+  async getWebhookStats(
+    webhookId: string,
+    organizationId: string
+  ): Promise<WebhookStats | null> {
+    const webhook = await this.getWebhookById(webhookId, organizationId);
+    if (!webhook) {
+      return null;
+    }
+
+    const stats = await this.db('webhook_deliveries')
+      .where({ webhook_id: webhookId })
+      .select(
+        this.db.raw('COUNT(*) as total_deliveries'),
+        this.db.raw("COUNT(*) FILTER (WHERE status = 'delivered') as successful_deliveries"),
+        this.db.raw("COUNT(*) FILTER (WHERE status = 'failed') as failed_deliveries"),
+        this.db.raw('AVG(response_time_ms) as avg_response_time_ms'),
+        this.db.raw('MAX(delivered_at) as last_success_at'),
+        this.db.raw("MAX(last_attempt_at) FILTER (WHERE status = 'failed') as last_failure_at")
+      )
+      .first();
+
+    return {
+      webhookId,
+      totalDeliveries: Number(stats?.total_deliveries) || 0,
+      successfulDeliveries: Number(stats?.successful_deliveries) || 0,
+      failedDeliveries: Number(stats?.failed_deliveries) || 0,
+      averageResponseTimeMs: Number(stats?.avg_response_time_ms) || 0,
+      lastDeliveryAt: webhook.lastTriggeredAt,
+      lastSuccessAt: stats?.last_success_at ? new Date(stats.last_success_at) : undefined,
+      lastFailureAt: stats?.last_failure_at ? new Date(stats.last_failure_at) : undefined,
+    };
+  }
+
+  // ============================================================================
+  // Helpers
+  // ============================================================================
+
+  private generateSecret(): string {
+    return `whsec_${crypto.randomBytes(32).toString('hex')}`;
+  }
+
+  signPayload(
+    payload: WebhookEventPayload,
+    secret: string
+  ): { timestamp: number; signature: string } {
+    const timestamp = Math.floor(Date.now() / 1000);
+    const payloadString = JSON.stringify(payload);
+    const signaturePayload = `${timestamp}.${payloadString}`;
+
+    const signature = crypto
+      .createHmac('sha256', secret)
+      .update(signaturePayload)
+      .digest('hex');
+
+    return { timestamp, signature: `v1=${signature}` };
+  }
+
+  verifySignature(
+    payload: string,
+    signature: string,
+    timestamp: number,
+    secret: string,
+    toleranceSeconds = 300
+  ): boolean {
+    // Check timestamp is within tolerance
+    const now = Math.floor(Date.now() / 1000);
+    if (Math.abs(now - timestamp) > toleranceSeconds) {
+      return false;
+    }
+
+    // Verify signature
+    const signaturePayload = `${timestamp}.${payload}`;
+    const expectedSignature = crypto
+      .createHmac('sha256', secret)
+      .update(signaturePayload)
+      .digest('hex');
+
+    const expectedFull = `v1=${expectedSignature}`;
+    return crypto.timingSafeEqual(
+      Buffer.from(signature),
+      Buffer.from(expectedFull)
+    );
+  }
+
+  private mapRowToWebhook(row: Record<string, unknown>): Webhook {
+    return {
+      id: row.id as string,
+      organizationId: row.organization_id as string,
+      name: row.name as string,
+      url: row.url as string,
+      secret: row.secret as string,
+      events: typeof row.events === 'string' ? JSON.parse(row.events) : row.events as string[],
+      description: row.description as string | undefined,
+      headers: row.headers
+        ? typeof row.headers === 'string'
+          ? JSON.parse(row.headers)
+          : row.headers
+        : undefined,
+      status: row.status as Webhook['status'],
+      retryPolicy:
+        typeof row.retry_policy === 'string'
+          ? JSON.parse(row.retry_policy)
+          : (row.retry_policy as Webhook['retryPolicy']),
+      createdAt: new Date(row.created_at as string),
+      updatedAt: new Date(row.updated_at as string),
+      createdBy: row.created_by as string,
+      lastTriggeredAt: row.last_triggered_at
+        ? new Date(row.last_triggered_at as string)
+        : undefined,
+      successCount: Number(row.success_count) || 0,
+      failureCount: Number(row.failure_count) || 0,
+    };
+  }
+
+  private mapRowToDelivery(row: Record<string, unknown>): WebhookDelivery {
+    return {
+      id: row.id as string,
+      webhookId: row.webhook_id as string,
+      eventType: row.event_type as string,
+      eventId: row.event_id as string,
+      payload:
+        typeof row.payload === 'string'
+          ? JSON.parse(row.payload)
+          : (row.payload as Record<string, unknown>),
+      status: row.status as DeliveryStatus,
+      attempts: Number(row.attempts) || 0,
+      lastAttemptAt: row.last_attempt_at
+        ? new Date(row.last_attempt_at as string)
+        : undefined,
+      nextRetryAt: row.next_retry_at
+        ? new Date(row.next_retry_at as string)
+        : undefined,
+      responseStatus: row.response_status
+        ? Number(row.response_status)
+        : undefined,
+      responseBody: row.response_body as string | undefined,
+      responseTimeMs: row.response_time_ms
+        ? Number(row.response_time_ms)
+        : undefined,
+      errorMessage: row.error_message as string | undefined,
+      createdAt: new Date(row.created_at as string),
+      deliveredAt: row.delivered_at
+        ? new Date(row.delivered_at as string)
+        : undefined,
+    };
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/verticals/integrations/src/types/webhook.ts
+++ b/verticals/integrations/src/types/webhook.ts
@@ -1,0 +1,174 @@
+import { z } from 'zod';
+
+// ============================================================================
+// Webhook Event Types
+// ============================================================================
+
+export const WEBHOOK_EVENTS = {
+  // Client events
+  CLIENT_CREATED: 'client.created',
+  CLIENT_UPDATED: 'client.updated',
+  CLIENT_DELETED: 'client.deleted',
+
+  // Caregiver events
+  CAREGIVER_CREATED: 'caregiver.created',
+  CAREGIVER_UPDATED: 'caregiver.updated',
+  CAREGIVER_DELETED: 'caregiver.deleted',
+
+  // Visit events
+  VISIT_SCHEDULED: 'visit.scheduled',
+  VISIT_STARTED: 'visit.started',
+  VISIT_COMPLETED: 'visit.completed',
+  VISIT_CANCELLED: 'visit.cancelled',
+  VISIT_MISSED: 'visit.missed',
+
+  // EVV events
+  EVV_CLOCK_IN: 'evv.clock_in',
+  EVV_CLOCK_OUT: 'evv.clock_out',
+  EVV_LOCATION_VERIFIED: 'evv.location_verified',
+  EVV_SIGNATURE_CAPTURED: 'evv.signature_captured',
+
+  // Care plan events
+  CARE_PLAN_CREATED: 'care_plan.created',
+  CARE_PLAN_UPDATED: 'care_plan.updated',
+  CARE_PLAN_APPROVED: 'care_plan.approved',
+
+  // Billing events
+  INVOICE_CREATED: 'invoice.created',
+  INVOICE_SENT: 'invoice.sent',
+  PAYMENT_RECEIVED: 'payment.received',
+
+  // Alert events
+  ALERT_TRIGGERED: 'alert.triggered',
+  ALERT_RESOLVED: 'alert.resolved',
+
+  // Document events
+  DOCUMENT_UPLOADED: 'document.uploaded',
+  DOCUMENT_SIGNED: 'document.signed',
+} as const;
+
+export type WebhookEventType = (typeof WEBHOOK_EVENTS)[keyof typeof WEBHOOK_EVENTS];
+
+// ============================================================================
+// Webhook Configuration
+// ============================================================================
+
+export const WebhookStatusSchema = z.enum(['active', 'inactive', 'suspended']);
+export type WebhookStatus = z.infer<typeof WebhookStatusSchema>;
+
+export const CreateWebhookSchema = z.object({
+  name: z.string().min(1).max(100),
+  url: z.string().url(),
+  events: z.array(z.string()).min(1),
+  description: z.string().max(500).optional(),
+  headers: z.record(z.string()).optional(),
+  retryPolicy: z
+    .object({
+      maxRetries: z.number().int().min(0).max(10).default(3),
+      retryDelayMs: z.number().int().min(1000).max(300000).default(5000),
+      exponentialBackoff: z.boolean().default(true),
+    })
+    .optional(),
+});
+
+export type CreateWebhookInput = z.infer<typeof CreateWebhookSchema>;
+
+export const UpdateWebhookSchema = CreateWebhookSchema.partial().extend({
+  status: WebhookStatusSchema.optional(),
+});
+
+export type UpdateWebhookInput = z.infer<typeof UpdateWebhookSchema>;
+
+export interface Webhook {
+  id: string;
+  organizationId: string;
+  name: string;
+  url: string;
+  secret: string;
+  events: string[];
+  description?: string;
+  headers?: Record<string, string>;
+  status: WebhookStatus;
+  retryPolicy: {
+    maxRetries: number;
+    retryDelayMs: number;
+    exponentialBackoff: boolean;
+  };
+  createdAt: Date;
+  updatedAt: Date;
+  createdBy: string;
+  lastTriggeredAt?: Date;
+  successCount: number;
+  failureCount: number;
+}
+
+// ============================================================================
+// Webhook Delivery
+// ============================================================================
+
+export const DeliveryStatusSchema = z.enum([
+  'pending',
+  'delivered',
+  'failed',
+  'retrying',
+]);
+export type DeliveryStatus = z.infer<typeof DeliveryStatusSchema>;
+
+export interface WebhookDelivery {
+  id: string;
+  webhookId: string;
+  eventType: string;
+  eventId: string;
+  payload: Record<string, unknown>;
+  status: DeliveryStatus;
+  attempts: number;
+  lastAttemptAt?: Date;
+  nextRetryAt?: Date;
+  responseStatus?: number;
+  responseBody?: string;
+  responseTimeMs?: number;
+  errorMessage?: string;
+  createdAt: Date;
+  deliveredAt?: Date;
+}
+
+// ============================================================================
+// Webhook Event Payload
+// ============================================================================
+
+export interface WebhookEventPayload<T = Record<string, unknown>> {
+  id: string;
+  type: WebhookEventType;
+  timestamp: string;
+  organizationId: string;
+  data: T;
+  metadata?: {
+    triggeredBy?: string;
+    correlationId?: string;
+    source?: string;
+  };
+}
+
+// ============================================================================
+// Webhook Signature
+// ============================================================================
+
+export interface WebhookSignature {
+  timestamp: number;
+  signature: string;
+}
+
+// ============================================================================
+// Webhook Statistics
+// ============================================================================
+
+export interface WebhookStats {
+  webhookId: string;
+  totalDeliveries: number;
+  successfulDeliveries: number;
+  failedDeliveries: number;
+  averageResponseTimeMs: number;
+  lastDeliveryAt?: Date;
+  lastSuccessAt?: Date;
+  lastFailureAt?: Date;
+}

--- a/verticals/integrations/tsconfig.eslint.json
+++ b/verticals/integrations/tsconfig.eslint.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*",
+    "*.ts",
+    "*.js"
+  ],
+  "exclude": []
+}

--- a/verticals/integrations/tsconfig.json
+++ b/verticals/integrations/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary
- New `@folkcare/integrations` vertical with comprehensive webhook service
- Webhook CRUD operations (create, update, delete, regenerate secret)
- Event triggering system with retry logic (exponential backoff)
- Delivery tracking and history
- Statistics and metrics endpoints
- HMAC signature verification for security
- Database migration for webhooks and webhook_deliveries tables

## Event types supported
- Client events (created, updated, deleted)
- Caregiver events (created, updated, deleted)
- Visit events (scheduled, started, completed, cancelled, missed)
- EVV events (clock_in, clock_out, location_verified, signature_captured)
- Care plan events (created, updated, approved)
- Billing events (invoice_created, sent, payment_received)
- Alert events (triggered, resolved)
- Document events (uploaded, signed)

## API Endpoints
- `GET /api/webhooks` - List webhooks
- `POST /api/webhooks` - Create webhook
- `GET /api/webhooks/:id` - Get webhook
- `PATCH /api/webhooks/:id` - Update webhook
- `DELETE /api/webhooks/:id` - Delete webhook
- `POST /api/webhooks/:id/regenerate-secret` - Regenerate secret
- `GET /api/webhooks/:id/deliveries` - Get delivery history
- `GET /api/webhooks/:id/stats` - Get statistics
- `POST /api/webhooks/:id/deliveries/:deliveryId/retry` - Retry delivery

## Test plan
- [ ] Run migration on local database
- [ ] Test webhook creation via API
- [ ] Test event triggering
- [ ] Verify delivery tracking

Closes #917

🤖 Generated with [Claude Code](https://claude.com/claude-code)