### PR TITLE
fix: remove develop branch from Deploy workflow triggers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - production  # Production deployments
       - preview     # Preview deployments (preview branch uses Vercel preview environment)
-      - develop     # Develop deployments (uses preview environment for testing)
   workflow_dispatch:
     inputs:
       environment:
@@ -152,7 +151,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: |
-      (github.event_name == 'push' && (github.ref == 'refs/heads/preview' || github.ref == 'refs/heads/develop')) ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/preview') ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'preview')
     environment:
       name: preview


### PR DESCRIPTION
## Summary
- Remove `develop` branch from Deploy workflow push triggers
- Remove develop branch check from deploy-preview job condition

Per branch strategy:
- `develop` → GitHub Pages showcase only (no Vercel deployment)
- `preview` → Vercel preview environment
- `production` → Vercel production environment

## Impact
Low - Stops unnecessary preview deployments when pushing to develop branch.

Fixes #1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)