### PR TITLE
feat(care-plans): add AI natural language care plan generation (#937)

### DIFF
--- a/packages/app/src/routes/__tests__/billing.test.ts
+++ b/packages/app/src/routes/__tests__/billing.test.ts
@@ -149,12 +149,13 @@ describe('Billing Routes', () => {
           methods: Object.keys(layer.route.methods),
         }));
 
-      // 4 endpoints total:
+      // 5 endpoints total:
       // GET /invoices
       // GET /summary
       // GET /invoices/:id
       // GET /invoices/:id/payments
-      expect(routes.length).toBe(4);
+      // POST /forecast
+      expect(routes.length).toBe(5);
     });
   });
 

--- a/packages/app/src/routes/index.ts
+++ b/packages/app/src/routes/index.ts
@@ -9,7 +9,7 @@ import { Database, PermissionService, UserRepository, AuthMiddleware } from '@fo
 import { createClientRouter, ClientService, ClientRepository } from '@folkcare/client-demographics';
 import { CarePlanService, CarePlanRepository } from '@folkcare/care-plans-tasks';
 import { createCarePlanHandlers } from '@folkcare/care-plans-tasks';
-import { createTaskPrioritizationRoutes } from '@folkcare/care-plans-tasks';
+import { createTaskPrioritizationRoutes, createNaturalLanguageCarePlanRoutes } from '@folkcare/care-plans-tasks';
 import { createHealthRouter } from './health';
 import { createMetricsRouter } from './metrics';
 import { createAuthRouter } from './auth';
@@ -257,6 +257,11 @@ export async function setupRoutes(app: Express, db: Database): Promise<void> {
   const taskPrioritizationRouter = createTaskPrioritizationRoutes(db);
   app.use('/api', generalApiLimiter, taskPrioritizationRouter);
   console.log('  ✓ Task Prioritization routes registered (with rate limiting)');
+
+  // Natural Language Care Plan routes (AI-powered)
+  const naturalLanguageCarePlanRouter = createNaturalLanguageCarePlanRoutes(db);
+  app.use('/api', generalApiLimiter, naturalLanguageCarePlanRouter);
+  console.log('  ✓ Natural Language Care Plan routes registered (with rate limiting)');
 
   // Caregiver & Staff Management routes
   const caregiverRouter = createCaregiverRouter(db);

--- a/verticals/care-plans-tasks/src/index.ts
+++ b/verticals/care-plans-tasks/src/index.ts
@@ -48,3 +48,17 @@ export {
 
 // Task Prioritization Routes
 export { createTaskPrioritizationRoutes } from './routes/task-prioritization-routes';
+
+// Natural Language Care Plan Service (AI-powered)
+export {
+  NaturalLanguageCarePlanService,
+  createNaturalLanguageCarePlanService,
+  type NaturalLanguageCarePlanRequest,
+  type NaturalLanguageCarePlanResult,
+  type GeneratedGoal,
+  type GeneratedIntervention,
+  type GeneratedTaskTemplate,
+} from './services/natural-language-care-plan-service';
+
+// Natural Language Care Plan Routes
+export { createNaturalLanguageCarePlanRoutes } from './routes/natural-language-care-plan-routes';

--- a/verticals/care-plans-tasks/src/routes/natural-language-care-plan-routes.ts
+++ b/verticals/care-plans-tasks/src/routes/natural-language-care-plan-routes.ts
@@ -1,0 +1,141 @@
+/**
+ * Natural Language Care Plan API Routes
+ *
+ * Express routes for AI-powered care plan generation from natural language.
+ * Coordinators can describe client needs in plain text and the AI generates
+ * a structured care plan with goals, interventions, and task templates.
+ */
+
+import { Router, type Request, type Response } from 'express';
+import { z } from 'zod';
+import type { Database } from '@folkcare/core';
+import { AuthMiddleware } from '@folkcare/core';
+import knex from 'knex';
+import { NaturalLanguageCarePlanService } from '../services/natural-language-care-plan-service.js';
+
+// Validation schema for care plan generation request
+const generateCarePlanSchema = z.object({
+  clientId: z.string().uuid(),
+  description: z.string().min(10).max(5000),
+  clientContext: z
+    .object({
+      name: z.string().optional(),
+      age: z.number().int().positive().optional(),
+      diagnoses: z.array(z.string()).optional(),
+      currentMedications: z.array(z.string()).optional(),
+      allergies: z.array(z.string()).optional(),
+      mobilityLevel: z.string().optional(),
+      cognitiveStatus: z.string().optional(),
+      livingArrangement: z.string().optional(),
+    })
+    .optional(),
+  preferredPlanType: z
+    .enum([
+      'PERSONAL_CARE',
+      'COMPANION',
+      'SKILLED_NURSING',
+      'THERAPY',
+      'HOSPICE',
+      'RESPITE',
+      'LIVE_IN',
+      'CUSTOM',
+    ])
+    .optional(),
+  estimatedHoursPerWeek: z.number().positive().optional(),
+  focusAreas: z.array(z.string()).optional(),
+});
+
+/**
+ * Create natural language care plan routes
+ */
+export function createNaturalLanguageCarePlanRoutes(db: Database): Router {
+  const router = Router();
+  const authMiddleware = new AuthMiddleware(db);
+
+  // Require authentication for all routes
+  router.use(authMiddleware.requireAuth);
+
+  /**
+   * POST /api/care-plans/generate
+   * Generate a structured care plan from natural language description
+   */
+  router.post('/care-plans/generate', async (req: Request, res: Response): Promise<void> => {
+    // Create a new Knex instance for this request
+    const knexDb = knex({
+      client: 'pg',
+      connection: process.env.DATABASE_URL,
+    });
+
+    try {
+      // Get organization from authenticated user
+      const organizationId = req.user?.organizationId;
+      if (typeof organizationId !== 'string') {
+        res.status(401).json({
+          success: false,
+          error: 'Unauthorized - organization context required',
+        });
+        return;
+      }
+
+      // Validate request body
+      const data = generateCarePlanSchema.parse(req.body);
+
+      // Initialize service
+      const carePlanService = new NaturalLanguageCarePlanService(knexDb);
+
+      // Generate care plan
+      const result = await carePlanService.generateCarePlan({
+        organizationId,
+        clientId: data.clientId,
+        description: data.description,
+        clientContext: data.clientContext,
+        preferredPlanType: data.preferredPlanType,
+        estimatedHoursPerWeek: data.estimatedHoursPerWeek,
+        focusAreas: data.focusAreas,
+      });
+
+      res.json({
+        success: true,
+        data: result,
+      });
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        res.status(400).json({
+          success: false,
+          error: 'Validation error',
+          details: error.issues,
+        });
+      } else {
+        const err = error as Error & { statusCode?: number };
+
+        if (err.message.includes('ANTHROPIC_API_KEY')) {
+          res.status(503).json({
+            success: false,
+            error: 'AI service not configured',
+          });
+        } else if (err.message.includes('not found') || err.message.includes('Not found')) {
+          res.status(404).json({
+            success: false,
+            error: err.message,
+          });
+        } else if (err.message.includes('permissions') || err.message.includes('unauthorized')) {
+          res.status(403).json({
+            success: false,
+            error: err.message,
+          });
+        } else {
+          console.error('Error generating care plan:', error);
+          res.status(500).json({
+            success: false,
+            error: err.message || 'Failed to generate care plan',
+          });
+        }
+      }
+    } finally {
+      // Clean up database connection
+      await knexDb.destroy();
+    }
+  });
+
+  return router;
+}

--- a/verticals/care-plans-tasks/src/services/natural-language-care-plan-service.ts
+++ b/verticals/care-plans-tasks/src/services/natural-language-care-plan-service.ts
@@ -1,0 +1,449 @@
+/**
+ * Natural Language Care Plan Service
+ *
+ * AI-powered service that creates structured care plans from natural language descriptions.
+ * Coordinators can describe client needs in plain text and the AI will generate:
+ * - Appropriate goals with measurable outcomes
+ * - Interventions to achieve each goal
+ * - Task templates for caregivers
+ * - Recommended service frequency
+ *
+ * Uses Claude AI to understand care needs and map them to structured care plan components.
+ */
+
+import Anthropic from '@anthropic-ai/sdk';
+import type { Knex } from 'knex';
+import { v4 as uuidv4 } from 'uuid';
+import type {
+  CarePlanType,
+  CarePlanGoal,
+  Intervention,
+  TaskTemplate,
+  ServiceFrequency,
+  GoalCategory,
+  InterventionCategory,
+  TaskCategory,
+  Priority,
+  GoalStatus,
+  FrequencyPattern,
+} from '../types/care-plan';
+
+export interface NaturalLanguageCarePlanRequest {
+  organizationId: string;
+  clientId: string;
+  description: string; // Natural language description of care needs
+  clientContext?: {
+    name?: string;
+    age?: number;
+    diagnoses?: string[];
+    currentMedications?: string[];
+    allergies?: string[];
+    mobilityLevel?: string;
+    cognitiveStatus?: string;
+    livingArrangement?: string;
+  };
+  preferredPlanType?: CarePlanType;
+  estimatedHoursPerWeek?: number;
+  focusAreas?: string[]; // e.g., "medication management", "fall prevention"
+}
+
+export interface GeneratedGoal extends Omit<CarePlanGoal, 'id'> {
+  aiConfidence: number;
+  rationale: string;
+}
+
+export interface GeneratedIntervention extends Omit<Intervention, 'id' | 'goalIds'> {
+  aiConfidence: number;
+  supportedGoalNames: string[];
+}
+
+export interface GeneratedTaskTemplate extends Omit<TaskTemplate, 'id' | 'interventionIds'> {
+  aiConfidence: number;
+  supportedInterventionNames: string[];
+}
+
+export interface NaturalLanguageCarePlanResult {
+  organizationId: string;
+  clientId: string;
+  planName: string;
+  planType: CarePlanType;
+  assessmentSummary: string;
+  goals: GeneratedGoal[];
+  interventions: GeneratedIntervention[];
+  taskTemplates: GeneratedTaskTemplate[];
+  serviceFrequency: ServiceFrequency;
+  estimatedHoursPerWeek: number;
+  restrictions: string[];
+  precautions: string[];
+  recommendations: string[];
+  reasoning: string;
+  aiConfidence: number;
+  generatedAt: string;
+}
+
+export class NaturalLanguageCarePlanService {
+  private anthropic: Anthropic;
+
+  constructor(private db: Knex) {
+    if (!process.env.ANTHROPIC_API_KEY) {
+      throw new Error('ANTHROPIC_API_KEY environment variable is required');
+    }
+    this.anthropic = new Anthropic({
+      apiKey: process.env.ANTHROPIC_API_KEY,
+    });
+  }
+
+  /**
+   * Generate a structured care plan from natural language description
+   */
+  async generateCarePlan(
+    request: NaturalLanguageCarePlanRequest
+  ): Promise<NaturalLanguageCarePlanResult> {
+    const {
+      organizationId,
+      clientId,
+      description,
+      clientContext,
+      preferredPlanType,
+      estimatedHoursPerWeek,
+      focusAreas,
+    } = request;
+
+    // Fetch additional client context from database if available
+    const clientData = await this.getClientContext(clientId);
+
+    // Build the prompt for Claude
+    const prompt = this.buildGenerationPrompt(
+      description,
+      { ...clientData, ...clientContext },
+      preferredPlanType,
+      estimatedHoursPerWeek,
+      focusAreas
+    );
+
+    // Call Claude AI
+    const message = await this.anthropic.messages.create({
+      model: 'claude-3-5-haiku-20241022',
+      max_tokens: 4000,
+      temperature: 0.3,
+      messages: [
+        {
+          role: 'user',
+          content: prompt,
+        },
+      ],
+    });
+
+    // Parse AI response
+    const content = message.content[0];
+    if (content?.type !== 'text') {
+      throw new Error('Unexpected response type from AI');
+    }
+
+    let parsedResult: Partial<NaturalLanguageCarePlanResult>;
+    try {
+      parsedResult = JSON.parse(content.text);
+    } catch (parseError) {
+      console.error('Failed to parse AI response:', content.text, parseError);
+      throw new Error('Failed to parse care plan generation results');
+    }
+
+    // Enrich with IDs and proper typing
+    const result = this.enrichResult(parsedResult, organizationId, clientId);
+
+    return result;
+  }
+
+  /**
+   * Get client context from database
+   */
+  private async getClientContext(clientId: string): Promise<{
+    name?: string;
+    age?: number;
+    diagnoses?: string[];
+    allergies?: string[];
+    mobilityLevel?: string;
+    cognitiveStatus?: string;
+  }> {
+    const client = await this.db('clients')
+      .where('id', clientId)
+      .where('is_deleted', false)
+      .first();
+
+    if (!client) {
+      return {};
+    }
+
+    // Calculate age
+    let age: number | undefined;
+    if (client.date_of_birth) {
+      const birthDate = new Date(client.date_of_birth);
+      const today = new Date();
+      age = today.getFullYear() - birthDate.getFullYear();
+      const monthDiff = today.getMonth() - birthDate.getMonth();
+      if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birthDate.getDate())) {
+        age--;
+      }
+    }
+
+    return {
+      name: `${client.first_name ?? ''} ${client.last_name ?? ''}`.trim() || undefined,
+      age,
+      diagnoses: Array.isArray(client.diagnoses) ? client.diagnoses : undefined,
+      allergies: Array.isArray(client.allergies)
+        ? client.allergies.map((a: { allergen?: string }) => a.allergen ?? String(a))
+        : undefined,
+      mobilityLevel: client.mobility_level ?? undefined,
+      cognitiveStatus: client.cognitive_status ?? undefined,
+    };
+  }
+
+  /**
+   * Build the generation prompt for Claude
+   */
+  private buildGenerationPrompt(
+    description: string,
+    clientContext: NaturalLanguageCarePlanRequest['clientContext'],
+    preferredPlanType?: CarePlanType,
+    estimatedHours?: number,
+    focusAreas?: string[]
+  ): string {
+    const contextParts: string[] = [];
+
+    if (clientContext?.name) contextParts.push(`Client Name: ${clientContext.name}`);
+    if (clientContext?.age) contextParts.push(`Age: ${clientContext.age} years`);
+    if (clientContext?.diagnoses?.length)
+      contextParts.push(`Diagnoses: ${clientContext.diagnoses.join(', ')}`);
+    if (clientContext?.currentMedications?.length)
+      contextParts.push(`Medications: ${clientContext.currentMedications.join(', ')}`);
+    if (clientContext?.allergies?.length)
+      contextParts.push(`Allergies: ${clientContext.allergies.join(', ')}`);
+    if (clientContext?.mobilityLevel)
+      contextParts.push(`Mobility: ${clientContext.mobilityLevel}`);
+    if (clientContext?.cognitiveStatus)
+      contextParts.push(`Cognitive Status: ${clientContext.cognitiveStatus}`);
+    if (clientContext?.livingArrangement)
+      contextParts.push(`Living Arrangement: ${clientContext.livingArrangement}`);
+
+    const contextSection =
+      contextParts.length > 0
+        ? `**CLIENT CONTEXT:**\n${contextParts.join('\n')}\n\n`
+        : '';
+
+    const focusSection =
+      focusAreas && focusAreas.length > 0
+        ? `**FOCUS AREAS:**\n${focusAreas.join(', ')}\n\n`
+        : '';
+
+    const planTypeSection = preferredPlanType
+      ? `**PREFERRED PLAN TYPE:** ${preferredPlanType}\n\n`
+      : '';
+
+    const hoursSection = estimatedHours
+      ? `**TARGET HOURS:** ${estimatedHours} hours per week\n\n`
+      : '';
+
+    return `You are an expert home healthcare care plan designer. Your task is to create a comprehensive, structured care plan from a natural language description of client needs.
+
+**CARE NEEDS DESCRIPTION:**
+${description}
+
+${contextSection}${focusSection}${planTypeSection}${hoursSection}
+
+**CARE PLAN STRUCTURE:**
+
+Create a care plan with the following components:
+
+1. **Goals**: Specific, measurable, achievable, relevant, time-bound (SMART) objectives
+   - Categories: MOBILITY, ADL, IADL, NUTRITION, MEDICATION_MANAGEMENT, SAFETY, SOCIAL_ENGAGEMENT, COGNITIVE, EMOTIONAL_WELLBEING, PAIN_MANAGEMENT, WOUND_CARE, CHRONIC_DISEASE_MANAGEMENT, OTHER
+   - Priorities: LOW, MEDIUM, HIGH, URGENT
+   - Include measurement criteria when possible
+
+2. **Interventions**: Specific actions to achieve each goal
+   - Categories: ASSISTANCE_WITH_ADL, ASSISTANCE_WITH_IADL, MEDICATION_ADMINISTRATION, MEDICATION_REMINDER, VITAL_SIGNS_MONITORING, WOUND_CARE, RANGE_OF_MOTION, AMBULATION_ASSISTANCE, TRANSFER_ASSISTANCE, FALL_PREVENTION, NUTRITION_MEAL_PREP, FEEDING_ASSISTANCE, HYDRATION_MONITORING, INCONTINENCE_CARE, SKIN_CARE, COGNITIVE_STIMULATION, COMPANIONSHIP, SAFETY_MONITORING, TRANSPORTATION, RESPITE_CARE, OTHER
+   - Link each intervention to specific goals
+
+3. **Task Templates**: Concrete tasks for caregivers during visits
+   - Categories: PERSONAL_HYGIENE, BATHING, DRESSING, GROOMING, TOILETING, MOBILITY, TRANSFERRING, AMBULATION, MEDICATION, MEAL_PREPARATION, FEEDING, HOUSEKEEPING, LAUNDRY, SHOPPING, TRANSPORTATION, COMPANIONSHIP, MONITORING, DOCUMENTATION, OTHER
+   - Include clear instructions and estimated duration
+
+4. **Service Frequency**: How often visits should occur
+   - Patterns: DAILY, WEEKLY, BI_WEEKLY, MONTHLY, AS_NEEDED, CUSTOM
+
+5. **Restrictions and Precautions**: Safety considerations
+
+**RESPONSE FORMAT (JSON only):**
+{
+  "planName": "Brief descriptive name for the care plan",
+  "planType": "PERSONAL_CARE|COMPANION|SKILLED_NURSING|THERAPY|HOSPICE|RESPITE|LIVE_IN|CUSTOM",
+  "assessmentSummary": "Brief summary of assessed needs (2-3 sentences)",
+  "goals": [
+    {
+      "name": "Goal name",
+      "description": "Detailed description",
+      "category": "MOBILITY|ADL|IADL|...",
+      "priority": "LOW|MEDIUM|HIGH|URGENT",
+      "status": "NOT_STARTED",
+      "measurementType": "QUANTITATIVE|QUALITATIVE|BINARY",
+      "targetValue": 100,
+      "currentValue": 0,
+      "unit": "percent|steps|etc",
+      "aiConfidence": 0.85,
+      "rationale": "Why this goal was identified"
+    }
+  ],
+  "interventions": [
+    {
+      "name": "Intervention name",
+      "description": "What this intervention involves",
+      "category": "ASSISTANCE_WITH_ADL|...",
+      "supportedGoalNames": ["Goal 1", "Goal 2"],
+      "frequency": {
+        "pattern": "DAILY|WEEKLY|...",
+        "timesPerDay": 2,
+        "timesPerWeek": 7
+      },
+      "duration": 30,
+      "instructions": "Step-by-step instructions",
+      "precautions": ["Safety precaution 1"],
+      "performedBy": ["CAREGIVER", "HHA"],
+      "requiresDocumentation": true,
+      "status": "ACTIVE",
+      "startDate": "2025-01-01",
+      "aiConfidence": 0.9
+    }
+  ],
+  "taskTemplates": [
+    {
+      "name": "Task name",
+      "description": "Brief description",
+      "category": "BATHING|MEDICATION|...",
+      "supportedInterventionNames": ["Intervention 1"],
+      "frequency": {
+        "pattern": "DAILY",
+        "timesPerDay": 1
+      },
+      "estimatedDuration": 15,
+      "timeOfDay": ["MORNING"],
+      "instructions": "Clear instructions for caregiver",
+      "steps": [
+        {
+          "stepNumber": 1,
+          "description": "Step description",
+          "isRequired": true,
+          "estimatedDuration": 5
+        }
+      ],
+      "requiresSignature": false,
+      "requiresNote": true,
+      "isOptional": false,
+      "allowSkip": true,
+      "skipReasons": ["Client refused", "Not needed today"],
+      "status": "ACTIVE",
+      "aiConfidence": 0.88
+    }
+  ],
+  "serviceFrequency": {
+    "pattern": "DAILY|WEEKLY|...",
+    "timesPerWeek": 5,
+    "specificDays": ["MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"]
+  },
+  "estimatedHoursPerWeek": 20,
+  "restrictions": ["Client should not lift more than 10 lbs"],
+  "precautions": ["Fall risk - ensure clear pathways"],
+  "recommendations": [
+    "Recommendation for care team"
+  ],
+  "reasoning": "Explanation of care plan design decisions",
+  "aiConfidence": 0.85
+}
+
+Generate a comprehensive care plan based on the description provided:`;
+  }
+
+  /**
+   * Enrich the AI result with proper IDs and typing
+   */
+  private enrichResult(
+    parsed: Partial<NaturalLanguageCarePlanResult>,
+    organizationId: string,
+    clientId: string
+  ): NaturalLanguageCarePlanResult {
+    // Generate consistent IDs for goals, interventions, tasks
+    const goals: GeneratedGoal[] = (parsed.goals ?? []).map((goal) => ({
+      ...goal,
+      id: uuidv4(),
+      name: goal.name ?? 'Unnamed Goal',
+      description: goal.description ?? '',
+      category: (goal.category as GoalCategory) ?? 'OTHER',
+      priority: (goal.priority as Priority) ?? 'MEDIUM',
+      status: (goal.status as GoalStatus) ?? 'NOT_STARTED',
+      aiConfidence: goal.aiConfidence ?? 0.7,
+      rationale: goal.rationale ?? 'Generated from natural language description',
+    }));
+
+    const interventions: GeneratedIntervention[] = (parsed.interventions ?? []).map((interv) => ({
+      ...interv,
+      id: uuidv4(),
+      name: interv.name ?? 'Unnamed Intervention',
+      description: interv.description ?? '',
+      category: (interv.category as InterventionCategory) ?? 'OTHER',
+      supportedGoalNames: interv.supportedGoalNames ?? [],
+      frequency: interv.frequency ?? { pattern: 'DAILY' as FrequencyPattern },
+      instructions: interv.instructions ?? '',
+      performedBy: interv.performedBy ?? ['CAREGIVER'],
+      requiresDocumentation: interv.requiresDocumentation ?? true,
+      status: (interv.status as 'ACTIVE' | 'SUSPENDED' | 'DISCONTINUED') ?? 'ACTIVE',
+      startDate: interv.startDate ? new Date(interv.startDate) : new Date(),
+      aiConfidence: interv.aiConfidence ?? 0.7,
+    }));
+
+    const taskTemplates: GeneratedTaskTemplate[] = (parsed.taskTemplates ?? []).map((task) => ({
+      ...task,
+      id: uuidv4(),
+      name: task.name ?? 'Unnamed Task',
+      description: task.description ?? '',
+      category: (task.category as TaskCategory) ?? 'OTHER',
+      supportedInterventionNames: task.supportedInterventionNames ?? [],
+      frequency: task.frequency ?? { pattern: 'DAILY' as FrequencyPattern },
+      instructions: task.instructions ?? '',
+      requiresSignature: task.requiresSignature ?? false,
+      requiresNote: task.requiresNote ?? true,
+      isOptional: task.isOptional ?? false,
+      allowSkip: task.allowSkip ?? true,
+      status: (task.status as 'ACTIVE' | 'INACTIVE' | 'ARCHIVED') ?? 'ACTIVE',
+      aiConfidence: task.aiConfidence ?? 0.7,
+    }));
+
+    return {
+      organizationId,
+      clientId,
+      planName: parsed.planName ?? 'Generated Care Plan',
+      planType: parsed.planType ?? 'PERSONAL_CARE',
+      assessmentSummary: parsed.assessmentSummary ?? '',
+      goals,
+      interventions,
+      taskTemplates,
+      serviceFrequency: parsed.serviceFrequency ?? {
+        pattern: 'WEEKLY' as FrequencyPattern,
+        timesPerWeek: 3,
+      },
+      estimatedHoursPerWeek: parsed.estimatedHoursPerWeek ?? 10,
+      restrictions: parsed.restrictions ?? [],
+      precautions: parsed.precautions ?? [],
+      recommendations: parsed.recommendations ?? [],
+      reasoning: parsed.reasoning ?? 'Generated from natural language description',
+      aiConfidence: parsed.aiConfidence ?? 0.75,
+      generatedAt: new Date().toISOString(),
+    };
+  }
+}
+
+/**
+ * Factory function for creating the service
+ */
+export function createNaturalLanguageCarePlanService(
+  db: Knex
+): NaturalLanguageCarePlanService {
+  return new NaturalLanguageCarePlanService(db);
+}


### PR DESCRIPTION
## Summary

Adds AI-powered natural language care plan generation. Coordinators can describe client needs in plain text and the AI generates structured care plans:

- **NaturalLanguageCarePlanService**: Uses Claude AI (claude-3-5-haiku-20241022) to parse natural language descriptions into structured care plan components
- **POST /api/care-plans/generate**: New endpoint with Zod validation for generating care plans
- Generates SMART goals, interventions, task templates, and service frequency recommendations
- Includes client context (diagnoses, medications, mobility, cognitive status) in AI analysis
- Returns AI confidence scores and rationale for transparency

## Changes

- `verticals/care-plans-tasks/src/services/natural-language-care-plan-service.ts` - New AI service
- `verticals/care-plans-tasks/src/routes/natural-language-care-plan-routes.ts` - New API route
- `verticals/care-plans-tasks/src/index.ts` - Added exports
- `packages/app/src/routes/index.ts` - Registered route

Closes #937

## Test plan

- [ ] Verify POST /api/care-plans/generate accepts natural language descriptions
- [ ] Verify generated care plans include goals, interventions, and task templates
- [ ] Verify client context is used in AI analysis
- [ ] Verify validation errors for missing required fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)