### PR TITLE
feat(ai): add AI usage tracking per organization (#1043)

### DIFF
--- a/packages/app/src/routes/admin.ts
+++ b/packages/app/src/routes/admin.ts
@@ -3,8 +3,22 @@
  */
 
 import { Router, type Router as RouterType } from 'express';
+import { z } from 'zod';
+import knex from 'knex';
 import { getCacheService } from '@folkcare/core/service/cache.service';
+import { createAIUsageRepository } from '@folkcare/core/ai';
 import { requireAuth } from '../middleware/auth-context';
+
+/**
+ * Create a Knex instance for repository services that need it.
+ */
+function getKnexInstance(): ReturnType<typeof knex> {
+  const connectionString = process.env.DATABASE_URL ?? 'postgresql://postgres:postgres@localhost:5432/folk-care-0';
+  return knex({
+    client: 'pg',
+    connection: connectionString,
+  });
+}
 
 const router: RouterType = Router();
 
@@ -49,6 +63,152 @@ router.post('/cache/clear', async (req, res) => {
   } catch (error) {
     console.error('Error clearing cache:', error);
     res.status(500).json({ error: 'Failed to clear cache' });
+  }
+});
+
+// =============================================================================
+// AI Usage Tracking Endpoints
+// =============================================================================
+
+const aiUsageQuerySchema = z.object({
+  startDate: z.string().optional(),
+  endDate: z.string().optional(),
+  featureName: z.string().optional(),
+  category: z.enum(['safetyCritical', 'analysis', 'generation', 'embeddings']).optional(),
+  provider: z.string().optional(),
+  limit: z.coerce.number().min(1).max(1000).default(100),
+  offset: z.coerce.number().min(0).default(0),
+});
+
+/**
+ * Get AI usage records for an organization
+ *
+ * @route GET /admin/ai-usage/:organizationId
+ * @security Requires admin role
+ */
+router.get('/ai-usage/:organizationId', async (req, res) => {
+  try {
+    const { organizationId } = req.params;
+    const query = aiUsageQuerySchema.parse(req.query);
+
+    const db = getKnexInstance();
+    const repository = createAIUsageRepository(db);
+
+    const records = await repository.getUsage(
+      {
+        organizationId,
+        startDate: query.startDate !== undefined ? new Date(query.startDate) : undefined,
+        endDate: query.endDate !== undefined ? new Date(query.endDate) : undefined,
+        featureName: query.featureName,
+        category: query.category,
+        provider: query.provider,
+      },
+      query.limit,
+      query.offset
+    );
+
+    res.json({ records, count: records.length });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      res.status(400).json({ error: 'Invalid query parameters', details: error.issues });
+      return;
+    }
+    console.error('Error getting AI usage:', error);
+    res.status(500).json({ error: 'Failed to get AI usage' });
+  }
+});
+
+/**
+ * Get current month AI usage stats for an organization
+ *
+ * @route GET /admin/ai-usage/:organizationId/current-month
+ * @security Requires admin role
+ */
+router.get('/ai-usage/:organizationId/current-month', async (req, res) => {
+  try {
+    const { organizationId } = req.params;
+
+    const db = getKnexInstance();
+    const repository = createAIUsageRepository(db);
+
+    const stats = await repository.getCurrentMonthStats(organizationId);
+    res.json(stats);
+  } catch (error) {
+    console.error('Error getting current month AI stats:', error);
+    res.status(500).json({ error: 'Failed to get current month AI stats' });
+  }
+});
+
+/**
+ * Get monthly AI usage summary for an organization
+ *
+ * @route GET /admin/ai-usage/:organizationId/monthly-summary
+ * @security Requires admin role
+ */
+router.get('/ai-usage/:organizationId/monthly-summary', async (req, res) => {
+  try {
+    const { organizationId } = req.params;
+    const rawMonths = Number(req.query.months);
+    const months = Number.isNaN(rawMonths) || rawMonths === 0 ? 6 : rawMonths;
+
+    const db = getKnexInstance();
+    const repository = createAIUsageRepository(db);
+
+    const summary = await repository.getMonthlySummary(organizationId, months);
+    res.json({ summary });
+  } catch (error) {
+    console.error('Error getting monthly AI summary:', error);
+    res.status(500).json({ error: 'Failed to get monthly AI summary' });
+  }
+});
+
+/**
+ * Get AI cost breakdown by provider/model for an organization
+ *
+ * @route GET /admin/ai-usage/:organizationId/cost-breakdown
+ * @security Requires admin role
+ */
+router.get('/ai-usage/:organizationId/cost-breakdown', async (req, res) => {
+  try {
+    const { organizationId } = req.params;
+    const startDate = typeof req.query.startDate === 'string'
+      ? new Date(req.query.startDate)
+      : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000); // Default: last 30 days
+    const endDate = typeof req.query.endDate === 'string' ? new Date(req.query.endDate) : new Date();
+
+    const db = getKnexInstance();
+    const repository = createAIUsageRepository(db);
+
+    const breakdown = await repository.getCostBreakdown(organizationId, startDate, endDate);
+    res.json({ breakdown, startDate, endDate });
+  } catch (error) {
+    console.error('Error getting AI cost breakdown:', error);
+    res.status(500).json({ error: 'Failed to get AI cost breakdown' });
+  }
+});
+
+/**
+ * Get AI feature usage statistics for an organization
+ *
+ * @route GET /admin/ai-usage/:organizationId/feature-usage
+ * @security Requires admin role
+ */
+router.get('/ai-usage/:organizationId/feature-usage', async (req, res) => {
+  try {
+    const { organizationId } = req.params;
+    const startDate = typeof req.query.startDate === 'string'
+      ? new Date(req.query.startDate)
+      : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000); // Default: last 30 days
+    const endDate = typeof req.query.endDate === 'string' ? new Date(req.query.endDate) : new Date();
+
+    const db = getKnexInstance();
+    const repository = createAIUsageRepository(db);
+
+    const usage = await repository.getFeatureUsage(organizationId, startDate, endDate);
+    res.json({ usage, startDate, endDate });
+  } catch (error) {
+    console.error('Error getting AI feature usage:', error);
+    res.status(500).json({ error: 'Failed to get AI feature usage' });
   }
 });
 

--- a/packages/core/migrations/20251209000000_create_ai_usage_table.ts
+++ b/packages/core/migrations/20251209000000_create_ai_usage_table.ts
@@ -1,0 +1,88 @@
+/**
+ * Migration: Create ai_usage table
+ *
+ * Tracks AI inference usage per organization for cost visibility and quota management.
+ * Each AI operation (text generation, JSON generation, embeddings) logs usage here.
+ */
+
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('ai_usage', (table) => {
+    // Primary key
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+
+    // Organization reference (required for multi-tenant tracking)
+    table
+      .uuid('organization_id')
+      .notNullable()
+      .references('id')
+      .inTable('organizations')
+      .onDelete('CASCADE');
+
+    // Feature identification
+    table.string('feature_name', 100).notNullable().comment('Feature that triggered the AI call (e.g., "visit-note-summary")');
+    table.string('category', 50).notNullable().comment('Feature category (safety_critical, clinical_analysis, documentation, etc.)');
+
+    // Provider and model info
+    table.string('provider', 50).notNullable().comment('AI provider (anthropic, cloudflare, ollama)');
+    table.string('model', 100).notNullable().comment('Model used (e.g., claude-3-5-haiku, llama-3.2-3b)');
+
+    // Token usage
+    table.integer('input_tokens').notNullable().defaultTo(0).comment('Number of input tokens');
+    table.integer('output_tokens').notNullable().defaultTo(0).comment('Number of output tokens');
+
+    // Cost tracking (in cents for precision)
+    table.integer('estimated_cost_cents').notNullable().defaultTo(0).comment('Estimated cost in cents');
+
+    // Performance metrics
+    table.integer('latency_ms').comment('Response latency in milliseconds');
+    table.boolean('success').notNullable().defaultTo(true).comment('Whether the request succeeded');
+    table.text('error_message').comment('Error message if request failed');
+
+    // Timestamps
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+
+    // Indexes for efficient querying
+    table.index('organization_id');
+    table.index(['organization_id', 'created_at']);
+    table.index(['organization_id', 'feature_name']);
+    table.index(['organization_id', 'provider']);
+    table.index('created_at');
+    table.index('category');
+  });
+
+  // Add comment to table
+  await knex.raw(`
+    COMMENT ON TABLE ai_usage IS
+    'Tracks AI inference usage per organization for cost visibility, quota management, and value demonstration.';
+  `);
+
+  // Create a view for monthly usage summaries
+  await knex.raw(`
+    CREATE VIEW ai_usage_monthly_summary AS
+    SELECT
+      organization_id,
+      date_trunc('month', created_at) AS month,
+      feature_name,
+      provider,
+      COUNT(*) AS request_count,
+      SUM(input_tokens) AS total_input_tokens,
+      SUM(output_tokens) AS total_output_tokens,
+      SUM(estimated_cost_cents) AS total_cost_cents,
+      AVG(latency_ms)::integer AS avg_latency_ms,
+      COUNT(*) FILTER (WHERE success = false) AS error_count
+    FROM ai_usage
+    GROUP BY organization_id, date_trunc('month', created_at), feature_name, provider;
+  `);
+
+  await knex.raw(`
+    COMMENT ON VIEW ai_usage_monthly_summary IS
+    'Aggregated monthly AI usage metrics per organization, feature, and provider.';
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw('DROP VIEW IF EXISTS ai_usage_monthly_summary');
+  await knex.schema.dropTableIfExists('ai_usage');
+}

--- a/packages/core/src/ai/ai-usage-repository.ts
+++ b/packages/core/src/ai/ai-usage-repository.ts
@@ -1,0 +1,329 @@
+/**
+ * AI Usage Repository
+ *
+ * Data access layer for AI usage tracking.
+ * Stores and retrieves AI inference metrics per organization.
+ */
+
+import type { Knex } from 'knex';
+import type { AIFeatureCategory, AIProviderType } from './types.js';
+
+/**
+ * AI usage metrics for logging
+ */
+export interface AIUsageMetrics {
+  provider: AIProviderType;
+  model: string;
+  feature: string;
+  inputTokens: number;
+  outputTokens: number;
+  latencyMs: number;
+  success: boolean;
+  error?: string;
+  organizationId?: string;
+}
+
+export interface AIUsageRecord {
+  id: string;
+  organizationId: string;
+  featureName: string;
+  category: AIFeatureCategory;
+  provider: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  estimatedCostCents: number;
+  latencyMs: number | null;
+  success: boolean;
+  errorMessage: string | null;
+  createdAt: Date;
+}
+
+export interface AIUsageSummary {
+  organizationId: string;
+  month: Date;
+  featureName: string;
+  provider: string;
+  requestCount: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCostCents: number;
+  avgLatencyMs: number;
+  errorCount: number;
+}
+
+export interface AIUsageFilter {
+  organizationId: string;
+  startDate?: Date;
+  endDate?: Date;
+  featureName?: string;
+  category?: AIFeatureCategory;
+  provider?: string;
+  success?: boolean;
+}
+
+export interface CostBreakdown {
+  provider: string;
+  model: string;
+  requestCount: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCostCents: number;
+}
+
+export interface FeatureUsage {
+  featureName: string;
+  category: AIFeatureCategory;
+  requestCount: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCostCents: number;
+  avgLatencyMs: number;
+  successRate: number;
+}
+
+/**
+ * Cost rates per 1K tokens (in cents)
+ * These are approximate and should be updated as pricing changes
+ */
+const COST_RATES: Record<string, { input: number; output: number }> = {
+  // Anthropic Claude 3.5 Haiku
+  'claude-3-5-haiku-20241022': { input: 0.1, output: 0.5 },
+  // Cloudflare is free tier
+  '@cf/meta/llama-3.2-3b-instruct': { input: 0, output: 0 },
+  // Ollama is self-hosted (no cost)
+  'llama3.2:3b': { input: 0, output: 0 },
+};
+
+export class AIUsageRepository {
+  constructor(private db: Knex) {}
+
+  /**
+   * Calculate estimated cost in cents
+   */
+  private calculateCost(model: string, inputTokens: number, outputTokens: number): number {
+    const rates = COST_RATES[model];
+    if (rates === undefined) {
+      // Default to 0 for unknown models
+      return 0;
+    }
+    const inputCost = (inputTokens / 1000) * rates.input;
+    const outputCost = (outputTokens / 1000) * rates.output;
+    return Math.round(inputCost + outputCost);
+  }
+
+  /**
+   * Record AI usage from metrics callback
+   */
+  async recordUsage(metrics: AIUsageMetrics, category: AIFeatureCategory): Promise<string> {
+    const estimatedCostCents = this.calculateCost(
+      metrics.model,
+      metrics.inputTokens,
+      metrics.outputTokens
+    );
+
+    const [record] = await this.db('ai_usage')
+      .insert({
+        organization_id: metrics.organizationId,
+        feature_name: metrics.feature,
+        category,
+        provider: metrics.provider,
+        model: metrics.model,
+        input_tokens: metrics.inputTokens,
+        output_tokens: metrics.outputTokens,
+        estimated_cost_cents: estimatedCostCents,
+        latency_ms: metrics.latencyMs,
+        success: metrics.success,
+        error_message: metrics.error ?? null,
+      })
+      .returning('id');
+
+    return record.id as string;
+  }
+
+  /**
+   * Get usage records with filtering
+   */
+  async getUsage(filter: AIUsageFilter, limit = 100, offset = 0): Promise<AIUsageRecord[]> {
+    let query = this.db('ai_usage')
+      .where('organization_id', filter.organizationId)
+      .orderBy('created_at', 'desc')
+      .limit(limit)
+      .offset(offset);
+
+    if (filter.startDate !== undefined) {
+      query = query.where('created_at', '>=', filter.startDate);
+    }
+    if (filter.endDate !== undefined) {
+      query = query.where('created_at', '<=', filter.endDate);
+    }
+    if (filter.featureName !== undefined) {
+      query = query.where('feature_name', filter.featureName);
+    }
+    if (filter.category !== undefined) {
+      query = query.where('category', filter.category);
+    }
+    if (filter.provider !== undefined) {
+      query = query.where('provider', filter.provider);
+    }
+    if (filter.success !== undefined) {
+      query = query.where('success', filter.success);
+    }
+
+    const rows = await query;
+    return rows.map((row) => this.mapToRecord(row));
+  }
+
+  /**
+   * Get monthly usage summary
+   */
+  async getMonthlySummary(organizationId: string, months = 6): Promise<AIUsageSummary[]> {
+    const rows = await this.db('ai_usage_monthly_summary')
+      .where('organization_id', organizationId)
+      .where('month', '>=', this.db.raw("NOW() - INTERVAL '? months'", [months]))
+      .orderBy('month', 'desc')
+      .orderBy('feature_name');
+
+    return rows.map((row) => ({
+      organizationId: row.organization_id as string,
+      month: new Date(row.month as string),
+      featureName: row.feature_name as string,
+      provider: row.provider as string,
+      requestCount: Number(row.request_count),
+      totalInputTokens: Number(row.total_input_tokens),
+      totalOutputTokens: Number(row.total_output_tokens),
+      totalCostCents: Number(row.total_cost_cents),
+      avgLatencyMs: Number(row.avg_latency_ms),
+      errorCount: Number(row.error_count),
+    }));
+  }
+
+  /**
+   * Get cost breakdown by provider/model for a time range
+   */
+  async getCostBreakdown(
+    organizationId: string,
+    startDate: Date,
+    endDate: Date
+  ): Promise<CostBreakdown[]> {
+    const rows = await this.db('ai_usage')
+      .where('organization_id', organizationId)
+      .whereBetween('created_at', [startDate, endDate])
+      .groupBy('provider', 'model')
+      .select(
+        'provider',
+        'model',
+        this.db.raw('COUNT(*) as request_count'),
+        this.db.raw('SUM(input_tokens) as total_input_tokens'),
+        this.db.raw('SUM(output_tokens) as total_output_tokens'),
+        this.db.raw('SUM(estimated_cost_cents) as total_cost_cents')
+      )
+      .orderBy('total_cost_cents', 'desc');
+
+    return rows.map((row) => ({
+      provider: row.provider as string,
+      model: row.model as string,
+      requestCount: Number(row.request_count),
+      totalInputTokens: Number(row.total_input_tokens),
+      totalOutputTokens: Number(row.total_output_tokens),
+      totalCostCents: Number(row.total_cost_cents),
+    }));
+  }
+
+  /**
+   * Get feature usage statistics
+   */
+  async getFeatureUsage(
+    organizationId: string,
+    startDate: Date,
+    endDate: Date
+  ): Promise<FeatureUsage[]> {
+    const rows = await this.db('ai_usage')
+      .where('organization_id', organizationId)
+      .whereBetween('created_at', [startDate, endDate])
+      .groupBy('feature_name', 'category')
+      .select(
+        'feature_name',
+        'category',
+        this.db.raw('COUNT(*) as request_count'),
+        this.db.raw('SUM(input_tokens) as total_input_tokens'),
+        this.db.raw('SUM(output_tokens) as total_output_tokens'),
+        this.db.raw('SUM(estimated_cost_cents) as total_cost_cents'),
+        this.db.raw('AVG(latency_ms)::integer as avg_latency_ms'),
+        this.db.raw('COUNT(*) FILTER (WHERE success = true)::float / COUNT(*)::float as success_rate')
+      )
+      .orderBy('request_count', 'desc');
+
+    return rows.map((row) => ({
+      featureName: row.feature_name as string,
+      category: row.category as AIFeatureCategory,
+      requestCount: Number(row.request_count),
+      totalInputTokens: Number(row.total_input_tokens),
+      totalOutputTokens: Number(row.total_output_tokens),
+      totalCostCents: Number(row.total_cost_cents),
+      avgLatencyMs: Number.isNaN(Number(row.avg_latency_ms)) ? 0 : Number(row.avg_latency_ms),
+      successRate: Number.isNaN(Number(row.success_rate)) ? 0 : Number(row.success_rate),
+    }));
+  }
+
+  /**
+   * Get total usage statistics for current month
+   */
+  async getCurrentMonthStats(organizationId: string): Promise<{
+    requestCount: number;
+    totalInputTokens: number;
+    totalOutputTokens: number;
+    totalCostCents: number;
+    avgLatencyMs: number;
+    errorCount: number;
+  }> {
+    const [row] = await this.db('ai_usage')
+      .where('organization_id', organizationId)
+      .whereRaw("created_at >= date_trunc('month', NOW())")
+      .select(
+        this.db.raw('COUNT(*) as request_count'),
+        this.db.raw('COALESCE(SUM(input_tokens), 0) as total_input_tokens'),
+        this.db.raw('COALESCE(SUM(output_tokens), 0) as total_output_tokens'),
+        this.db.raw('COALESCE(SUM(estimated_cost_cents), 0) as total_cost_cents'),
+        this.db.raw('COALESCE(AVG(latency_ms), 0)::integer as avg_latency_ms'),
+        this.db.raw('COUNT(*) FILTER (WHERE success = false) as error_count')
+      );
+
+    return {
+      requestCount: Number(row.request_count),
+      totalInputTokens: Number(row.total_input_tokens),
+      totalOutputTokens: Number(row.total_output_tokens),
+      totalCostCents: Number(row.total_cost_cents),
+      avgLatencyMs: Number(row.avg_latency_ms),
+      errorCount: Number(row.error_count),
+    };
+  }
+
+  /**
+   * Map database row to AIUsageRecord
+   */
+  private mapToRecord(row: Record<string, unknown>): AIUsageRecord {
+    return {
+      id: row.id as string,
+      organizationId: row.organization_id as string,
+      featureName: row.feature_name as string,
+      category: row.category as AIFeatureCategory,
+      provider: row.provider as string,
+      model: row.model as string,
+      inputTokens: Number(row.input_tokens),
+      outputTokens: Number(row.output_tokens),
+      estimatedCostCents: Number(row.estimated_cost_cents),
+      latencyMs: row.latency_ms !== null && row.latency_ms !== undefined ? Number(row.latency_ms) : null,
+      success: row.success as boolean,
+      errorMessage: row.error_message as string | null,
+      createdAt: new Date(row.created_at as string),
+    };
+  }
+}
+
+/**
+ * Factory function to create AI usage repository
+ */
+export function createAIUsageRepository(db: Knex): AIUsageRepository {
+  return new AIUsageRepository(db);
+}

--- a/packages/core/src/ai/index.ts
+++ b/packages/core/src/ai/index.ts
@@ -87,3 +87,18 @@ export {
   getProviderForFeature,
   getProviderForCategory,
 } from './providers/provider-factory.js';
+
+// Usage Tracking
+export type {
+  AIUsageMetrics,
+  AIUsageRecord,
+  AIUsageSummary,
+  AIUsageFilter,
+  CostBreakdown,
+  FeatureUsage,
+} from './ai-usage-repository.js';
+
+export {
+  AIUsageRepository,
+  createAIUsageRepository,
+} from './ai-usage-repository.js';


### PR DESCRIPTION
## Summary
- Create `ai_usage` table migration for tracking AI inference usage per organization
- Add `ai_usage_monthly_summary` PostgreSQL view for aggregated metrics  
- Implement `AIUsageRepository` with comprehensive query methods
- Add admin API endpoints for usage visibility and cost management

## Changes

### Migration (`20251209000000_create_ai_usage_table.ts`)
- Creates `ai_usage` table with columns for:
  - Organization reference (multi-tenant)
  - Feature identification (name, category)
  - Provider/model tracking
  - Token usage (input/output)
  - Cost estimation (in cents)
  - Performance metrics (latency, success rate)
- Creates `ai_usage_monthly_summary` view for aggregated reporting
- Indexes for efficient querying by org, feature, provider, and date

### Repository (`ai-usage-repository.ts`)
- `recordUsage()` - Log AI inference metrics with cost calculation
- `getUsage()` - Query records with filtering (date, feature, category, provider)
- `getMonthlySummary()` - Aggregated monthly metrics
- `getCostBreakdown()` - Cost analysis by provider/model
- `getFeatureUsage()` - Usage statistics by feature
- `getCurrentMonthStats()` - Current month totals

### Admin API Endpoints
- `GET /admin/ai-usage/:orgId` - Usage records with filtering
- `GET /admin/ai-usage/:orgId/current-month` - Current month stats
- `GET /admin/ai-usage/:orgId/monthly-summary` - Monthly summaries
- `GET /admin/ai-usage/:orgId/cost-breakdown` - Cost by provider/model
- `GET /admin/ai-usage/:orgId/feature-usage` - Usage by feature

## Test plan
- [x] All pre-commit checks pass (lint, typecheck, tests, build)
- [ ] Run migration on database
- [ ] Verify API endpoints return expected data
- [ ] Test filtering and pagination

Closes #1043

🤖 Generated with [Claude Code](https://claude.com/claude-code)