### PR TITLE
fix(web): serve correct HTML entry for showcase dev server

### DIFF
--- a/packages/web/vite.config.showcase.ts
+++ b/packages/web/vite.config.showcase.ts
@@ -6,7 +6,30 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    {
+      name: 'showcase-html-serve',
+      enforce: 'pre',
+      configureServer(server) {
+        server.middlewares.use((req, _res, next) => {
+          // Rewrite HTML page requests to serve index-showcase.html
+          const url = req.url || '';
+          // Match routes but not assets - serve showcase HTML for SPA routes
+          if (
+            url.startsWith('/folkcare') &&
+            !url.includes('.') &&
+            !url.includes('/@') &&
+            !url.includes('/src/') &&
+            !url.includes('/node_modules')
+          ) {
+            req.url = '/folkcare/index-showcase.html';
+          }
+          next();
+        });
+      },
+    },
+  ],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary
- Added Vite plugin to rewrite requests to `index-showcase.html` for SPA routes in showcase mode
- Fixes issue where dev server was serving `index.html` (main app) instead of `index-showcase.html`
- The plugin matches `/folkcare/*` routes (excluding assets) and rewrites to the correct entry point

## Test plan
- [x] Run `npm run dev:showcase` 
- [x] Visit `http://localhost:5173/folkcare/` - should show showcase app (not main app)
- [x] Navigate to routes like `/folkcare/dashboard` - should render correctly
- [x] Pre-commit checks pass (lint, typecheck, test, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)