### PR TITLE
feat(infra): add Terraform Infrastructure as Code (#598)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -40,6 +40,9 @@ paths = [
   # Ignore Kubernetes manifest templates with placeholder secrets
   '''k8s/secrets\.yaml''',
   '''deploy/k8s/.*''',
+  # Ignore Terraform example files with placeholder secrets
+  '''infra/terraform\.tfvars\.example''',
+  '''infra/README\.md''',
 ]
 
 # Ignore example/template files and false positive patterns

--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -1,0 +1,34 @@
+# Terraform state files (contain secrets)
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Local .terraform directories
+.terraform/
+
+# .tfvars files (may contain secrets)
+*.tfvars
+*.tfvars.json
+!terraform.tfvars.example
+
+# Lock file (can be committed for reproducibility, but often gitignored)
+# .terraform.lock.hcl
+
+# Override files
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# CLI configuration files
+.terraformrc
+terraform.rc
+
+# Plan files
+*.tfplan
+
+# Sensitive variable files
+*.auto.tfvars

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,192 @@
+# Folk Care Infrastructure as Code
+
+This directory contains Terraform configurations for managing Folk Care's infrastructure.
+
+## Overview
+
+| Resource | Provider | Description |
+|----------|----------|-------------|
+| Vercel | `vercel/vercel` | Frontend deployment, serverless functions |
+| Neon | `kislerdm/neon` | PostgreSQL database (production & preview) |
+| Upstash | `upstash/upstash` | Redis cache (production & preview) |
+
+## Prerequisites
+
+1. **Terraform** >= 1.5.0
+   ```bash
+   brew install terraform
+   # or
+   curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+   sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+   sudo apt-get update && sudo apt-get install terraform
+   ```
+
+2. **API Tokens** (set as environment variables):
+   ```bash
+   export VERCEL_API_TOKEN="your-vercel-token"
+   export NEON_API_KEY="your-neon-api-key"
+   export UPSTASH_EMAIL="your-upstash-email"
+   export UPSTASH_API_KEY="your-upstash-api-key"
+   ```
+
+## Getting Started
+
+### Initial Setup
+
+1. **Copy the example variables file:**
+   ```bash
+   cp terraform.tfvars.example terraform.tfvars
+   ```
+
+2. **Edit `terraform.tfvars`** with your values:
+   - `neon_org_id` - Find in Neon Console → Account Settings
+   - `jwt_secret` - Generate with `openssl rand -base64 32`
+   - `encryption_key` - Generate with `openssl rand -base64 32`
+
+3. **Initialize Terraform:**
+   ```bash
+   terraform init
+   ```
+
+4. **Review the plan:**
+   ```bash
+   terraform plan
+   ```
+
+5. **Apply the configuration:**
+   ```bash
+   terraform apply
+   ```
+
+### Importing Existing Resources
+
+If you have existing Vercel/Neon/Upstash resources, import them:
+
+```bash
+# Import Vercel project
+terraform import vercel_project.folkcare prj_xxxxxxxx
+
+# Import Neon project
+terraform import neon_project.folkcare your-project-id
+
+# Import Upstash Redis database
+terraform import upstash_redis_database.production your-database-id
+```
+
+## File Structure
+
+```
+infra/
+├── main.tf                    # Providers and shared configuration
+├── variables.tf               # Variable definitions
+├── outputs.tf                 # Output values
+├── backend.tf                 # State backend configuration
+├── vercel.tf                  # Vercel project and env vars
+├── neon.tf                    # Neon database configuration
+├── upstash.tf                 # Upstash Redis configuration
+├── terraform.tfvars.example   # Example variables file
+├── .gitignore                 # Ignore state and secrets
+└── README.md                  # This file
+```
+
+## Environment Variables
+
+The following environment variables are automatically configured in Vercel:
+
+| Variable | Description | Environments |
+|----------|-------------|--------------|
+| `DATABASE_URL` | Neon PostgreSQL connection string | production, preview |
+| `REDIS_URL` | Upstash Redis URL | production, preview |
+| `REDIS_TOKEN` | Upstash Redis auth token | production, preview |
+| `JWT_SECRET` | JWT signing secret | production, preview |
+| `ENCRYPTION_KEY` | Data encryption key | production, preview |
+| `NODE_ENV` | Environment name | production, preview |
+
+## State Management
+
+By default, Terraform state is stored locally. For team collaboration, configure a remote backend:
+
+### Terraform Cloud (Recommended)
+
+1. Create an account at [app.terraform.io](https://app.terraform.io)
+2. Create an organization and workspace
+3. Uncomment the `cloud` block in `backend.tf`
+4. Run `terraform init -migrate-state`
+
+### AWS S3
+
+1. Create an S3 bucket and DynamoDB table
+2. Uncomment the `s3` backend block in `backend.tf`
+3. Run `terraform init -migrate-state`
+
+## Common Operations
+
+### Update Environment Variables
+
+```bash
+# After changing variables
+terraform plan
+terraform apply
+```
+
+### Scale Database Compute
+
+Edit `terraform.tfvars`:
+```hcl
+neon_compute_size = {
+  min_cu = 0.5
+  max_cu = 4
+}
+```
+
+Then apply:
+```bash
+terraform apply
+```
+
+### Add a New Environment
+
+1. Add new branch resources in `neon.tf`
+2. Add new Redis database in `upstash.tf`
+3. Add environment variables in `vercel.tf`
+4. Run `terraform apply`
+
+## Security Notes
+
+1. **Never commit `terraform.tfvars`** - it contains secrets
+2. **Never commit `*.tfstate`** - it contains infrastructure details
+3. **Rotate secrets regularly** - regenerate JWT_SECRET and ENCRYPTION_KEY periodically
+4. **Use least privilege** - API tokens should have minimal required permissions
+
+## Troubleshooting
+
+### "Resource already exists"
+
+Import the existing resource:
+```bash
+terraform import <resource_type>.<name> <resource_id>
+```
+
+### "Provider authentication failed"
+
+Verify environment variables are set:
+```bash
+echo $VERCEL_API_TOKEN
+echo $NEON_API_KEY
+echo $UPSTASH_EMAIL
+echo $UPSTASH_API_KEY
+```
+
+### "State lock error"
+
+If using remote state and lock is stuck:
+```bash
+terraform force-unlock <lock_id>
+```
+
+## Resources
+
+- [Vercel Terraform Provider](https://registry.terraform.io/providers/vercel/vercel/latest/docs)
+- [Neon Terraform Provider](https://registry.terraform.io/providers/kislerdm/neon/latest/docs)
+- [Upstash Terraform Provider](https://registry.terraform.io/providers/upstash/upstash/latest/docs)
+- [Terraform Best Practices](https://www.terraform-best-practices.com/)

--- a/infra/backend.tf
+++ b/infra/backend.tf
@@ -1,0 +1,48 @@
+# Folk Care Terraform Backend Configuration
+#
+# This file configures where Terraform stores its state.
+# For team collaboration, we recommend using a remote backend.
+#
+# Options:
+# 1. Terraform Cloud (free tier available)
+# 2. AWS S3 + DynamoDB
+# 3. Azure Storage
+# 4. Google Cloud Storage
+#
+# For now, we use local state. To migrate to remote:
+# 1. Uncomment one of the backend blocks below
+# 2. Run: terraform init -migrate-state
+
+# =============================================================================
+# Local Backend (Default - for initial setup)
+# =============================================================================
+
+# State is stored locally in terraform.tfstate
+# WARNING: Do not commit terraform.tfstate to git (it contains secrets)
+
+# =============================================================================
+# Terraform Cloud Backend (Recommended for teams)
+# =============================================================================
+
+# terraform {
+#   cloud {
+#     organization = "neighborhood-lab"
+#     workspaces {
+#       name = "folkcare-infrastructure"
+#     }
+#   }
+# }
+
+# =============================================================================
+# AWS S3 Backend (Alternative)
+# =============================================================================
+
+# terraform {
+#   backend "s3" {
+#     bucket         = "folkcare-terraform-state"
+#     key            = "infrastructure/terraform.tfstate"
+#     region         = "us-east-1"
+#     encrypt        = true
+#     dynamodb_table = "folkcare-terraform-locks"
+#   }
+# }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,50 @@
+# Folk Care Infrastructure as Code
+# Terraform configuration for managing Vercel, Neon, and Upstash resources
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    vercel = {
+      source  = "vercel/vercel"
+      version = "~> 2.0"
+    }
+    neon = {
+      source  = "kislerdm/neon"
+      version = "~> 0.6"
+    }
+    upstash = {
+      source  = "upstash/upstash"
+      version = "~> 1.5"
+    }
+  }
+}
+
+# Provider configurations
+# API tokens should be set via environment variables:
+# - VERCEL_API_TOKEN
+# - NEON_API_KEY
+# - UPSTASH_EMAIL and UPSTASH_API_KEY
+
+provider "vercel" {
+  # Uses VERCEL_API_TOKEN environment variable
+  team = var.vercel_team_id
+}
+
+provider "neon" {
+  # Uses NEON_API_KEY environment variable
+}
+
+provider "upstash" {
+  # Uses UPSTASH_EMAIL and UPSTASH_API_KEY environment variables
+}
+
+# Local values for consistent naming
+locals {
+  project_name = "folkcare"
+  common_tags = {
+    project     = local.project_name
+    managed_by  = "terraform"
+    repository  = "neighborhood-lab/folk-care"
+  }
+}

--- a/infra/neon.tf
+++ b/infra/neon.tf
@@ -21,21 +21,25 @@ resource "neon_project" "folkcare" {
     suspend_timeout_seconds  = 300 # Suspend after 5 minutes of inactivity
   }
 
-  # Enable connection pooling
+  # PostgreSQL version
   pg_version = 15
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 # =============================================================================
 # Database Branches
 # =============================================================================
 
-# Production branch (main branch is created automatically with the project)
-resource "neon_branch" "production" {
+# Use the default "main" branch created with the project as production
+# Note: Neon automatically creates a "main" branch when the project is created
+# We reference it via data source to avoid conflicts
+data "neon_branch" "main" {
   project_id = neon_project.folkcare.id
-  name       = "production"
+  name       = "main"
 
-  # Production uses the main branch which is created with the project
-  # This is a reference to ensure proper dependency ordering
   depends_on = [neon_project.folkcare]
 }
 
@@ -44,8 +48,8 @@ resource "neon_branch" "preview" {
   project_id = neon_project.folkcare.id
   name       = "preview"
 
-  # Branch from production to include schema
-  parent_id = neon_branch.production.id
+  # Branch from main to inherit schema and data
+  parent_id = data.neon_branch.main.id
 }
 
 # =============================================================================
@@ -54,7 +58,7 @@ resource "neon_branch" "preview" {
 
 resource "neon_endpoint" "production" {
   project_id = neon_project.folkcare.id
-  branch_id  = neon_branch.production.id
+  branch_id  = data.neon_branch.main.id
 
   type = "read_write"
 
@@ -75,12 +79,18 @@ resource "neon_endpoint" "preview" {
 }
 
 # =============================================================================
-# Database Roles
+# Database Roles (one per branch - roles are branch-specific in Neon)
 # =============================================================================
 
-resource "neon_role" "app" {
+resource "neon_role" "production_app" {
   project_id = neon_project.folkcare.id
-  branch_id  = neon_branch.production.id
+  branch_id  = data.neon_branch.main.id
+  name       = "folkcare_app"
+}
+
+resource "neon_role" "preview_app" {
+  project_id = neon_project.folkcare.id
+  branch_id  = neon_branch.preview.id
   name       = "folkcare_app"
 }
 
@@ -90,14 +100,14 @@ resource "neon_role" "app" {
 
 resource "neon_database" "production" {
   project_id = neon_project.folkcare.id
-  branch_id  = neon_branch.production.id
+  branch_id  = data.neon_branch.main.id
   name       = "folkcare"
-  owner_name = neon_role.app.name
+  owner_name = neon_role.production_app.name
 }
 
 resource "neon_database" "preview" {
   project_id = neon_project.folkcare.id
   branch_id  = neon_branch.preview.id
   name       = "folkcare"
-  owner_name = neon_role.app.name
+  owner_name = neon_role.preview_app.name
 }

--- a/infra/neon.tf
+++ b/infra/neon.tf
@@ -1,0 +1,103 @@
+# Folk Care Neon PostgreSQL Configuration
+
+# =============================================================================
+# Neon Project
+# =============================================================================
+
+resource "neon_project" "folkcare" {
+  name      = local.project_name
+  region_id = var.neon_region
+
+  # Organization ID is required to prevent duplicate projects
+  org_id = var.neon_org_id
+
+  # Point-in-time recovery history retention
+  history_retention_seconds = var.neon_history_retention
+
+  # Default compute size for endpoints
+  default_endpoint_settings = {
+    autoscaling_limit_min_cu = var.neon_compute_size.min_cu
+    autoscaling_limit_max_cu = var.neon_compute_size.max_cu
+    suspend_timeout_seconds  = 300 # Suspend after 5 minutes of inactivity
+  }
+
+  # Enable connection pooling
+  pg_version = 15
+}
+
+# =============================================================================
+# Database Branches
+# =============================================================================
+
+# Production branch (main branch is created automatically with the project)
+resource "neon_branch" "production" {
+  project_id = neon_project.folkcare.id
+  name       = "production"
+
+  # Production uses the main branch which is created with the project
+  # This is a reference to ensure proper dependency ordering
+  depends_on = [neon_project.folkcare]
+}
+
+# Preview branch for staging/development
+resource "neon_branch" "preview" {
+  project_id = neon_project.folkcare.id
+  name       = "preview"
+
+  # Branch from production to include schema
+  parent_id = neon_branch.production.id
+}
+
+# =============================================================================
+# Compute Endpoints
+# =============================================================================
+
+resource "neon_endpoint" "production" {
+  project_id = neon_project.folkcare.id
+  branch_id  = neon_branch.production.id
+
+  type = "read_write"
+
+  autoscaling_limit_min_cu = var.neon_compute_size.min_cu
+  autoscaling_limit_max_cu = var.neon_compute_size.max_cu
+  suspend_timeout_seconds  = 0 # Never suspend in production
+}
+
+resource "neon_endpoint" "preview" {
+  project_id = neon_project.folkcare.id
+  branch_id  = neon_branch.preview.id
+
+  type = "read_write"
+
+  autoscaling_limit_min_cu = var.neon_compute_size.min_cu
+  autoscaling_limit_max_cu = var.neon_compute_size.max_cu
+  suspend_timeout_seconds  = 300 # Suspend after 5 minutes in preview
+}
+
+# =============================================================================
+# Database Roles
+# =============================================================================
+
+resource "neon_role" "app" {
+  project_id = neon_project.folkcare.id
+  branch_id  = neon_branch.production.id
+  name       = "folkcare_app"
+}
+
+# =============================================================================
+# Databases
+# =============================================================================
+
+resource "neon_database" "production" {
+  project_id = neon_project.folkcare.id
+  branch_id  = neon_branch.production.id
+  name       = "folkcare"
+  owner_name = neon_role.app.name
+}
+
+resource "neon_database" "preview" {
+  project_id = neon_project.folkcare.id
+  branch_id  = neon_branch.preview.id
+  name       = "folkcare"
+  owner_name = neon_role.app.name
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,98 @@
+# Folk Care Terraform Outputs
+
+# =============================================================================
+# Vercel Outputs
+# =============================================================================
+
+output "vercel_project_id" {
+  description = "Vercel project ID"
+  value       = vercel_project.folkcare.id
+}
+
+output "vercel_project_name" {
+  description = "Vercel project name"
+  value       = vercel_project.folkcare.name
+}
+
+output "vercel_production_url" {
+  description = "Vercel production URL"
+  value       = "https://${vercel_project_domain.production.domain}"
+}
+
+# =============================================================================
+# Neon Database Outputs
+# =============================================================================
+
+output "neon_project_id" {
+  description = "Neon project ID"
+  value       = neon_project.folkcare.id
+}
+
+output "neon_production_host" {
+  description = "Neon production database host"
+  value       = neon_endpoint.production.host
+  sensitive   = true
+}
+
+output "neon_preview_host" {
+  description = "Neon preview database host"
+  value       = neon_endpoint.preview.host
+  sensitive   = true
+}
+
+output "neon_production_connection_uri" {
+  description = "Neon production connection URI (pooled)"
+  value       = neon_branch.production.connection_uri
+  sensitive   = true
+}
+
+output "neon_preview_connection_uri" {
+  description = "Neon preview connection URI (pooled)"
+  value       = neon_branch.preview.connection_uri
+  sensitive   = true
+}
+
+# =============================================================================
+# Upstash Redis Outputs
+# =============================================================================
+
+output "upstash_production_endpoint" {
+  description = "Upstash Redis production endpoint"
+  value       = upstash_redis_database.production.endpoint
+  sensitive   = true
+}
+
+output "upstash_production_port" {
+  description = "Upstash Redis production port"
+  value       = upstash_redis_database.production.port
+}
+
+output "upstash_preview_endpoint" {
+  description = "Upstash Redis preview endpoint"
+  value       = upstash_redis_database.preview.endpoint
+  sensitive   = true
+}
+
+output "upstash_preview_port" {
+  description = "Upstash Redis preview port"
+  value       = upstash_redis_database.preview.port
+}
+
+# =============================================================================
+# Connection String Outputs (for local development reference)
+# =============================================================================
+
+output "connection_strings" {
+  description = "Connection strings for reference (sensitive)"
+  sensitive   = true
+  value = {
+    production = {
+      database = neon_branch.production.connection_uri
+      redis    = "rediss://:${upstash_redis_database.production.password}@${upstash_redis_database.production.endpoint}:${upstash_redis_database.production.port}"
+    }
+    preview = {
+      database = neon_branch.preview.connection_uri
+      redis    = "rediss://:${upstash_redis_database.preview.password}@${upstash_redis_database.preview.endpoint}:${upstash_redis_database.preview.port}"
+    }
+  }
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -42,7 +42,7 @@ output "neon_preview_host" {
 
 output "neon_production_connection_uri" {
   description = "Neon production connection URI (pooled)"
-  value       = neon_branch.production.connection_uri
+  value       = data.neon_branch.main.connection_uri
   sensitive   = true
 }
 
@@ -87,7 +87,7 @@ output "connection_strings" {
   sensitive   = true
   value = {
     production = {
-      database = neon_branch.production.connection_uri
+      database = data.neon_branch.main.connection_uri
       redis    = "rediss://:${upstash_redis_database.production.password}@${upstash_redis_database.production.endpoint}:${upstash_redis_database.production.port}"
     }
     preview = {

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -1,0 +1,56 @@
+# Folk Care Terraform Variables Example
+# Copy this file to terraform.tfvars and fill in the values
+# DO NOT commit terraform.tfvars to git (it contains secrets)
+
+# =============================================================================
+# Vercel Configuration
+# =============================================================================
+
+# Optional: Vercel team ID (leave null for personal account)
+vercel_team_id = null
+
+# GitHub repository configuration (defaults shown, change if needed)
+# vercel_git_repo = {
+#   type              = "github"
+#   repo              = "neighborhood-lab/folk-care"
+#   production_branch = "production"
+# }
+
+# =============================================================================
+# Neon Database Configuration
+# =============================================================================
+
+# REQUIRED: Your Neon organization ID
+# Find this in Neon Console → Account Settings → Organization settings
+neon_org_id = "org-xxxxxxxxxx"
+
+# Optional: Neon region (default: aws-us-east-1)
+# neon_region = "aws-us-east-1"
+
+# Optional: Compute size limits
+# neon_compute_size = {
+#   min_cu = 0.25
+#   max_cu = 2
+# }
+
+# =============================================================================
+# Upstash Redis Configuration
+# =============================================================================
+
+# Optional: Upstash region (default: us-east-1)
+# upstash_region = "us-east-1"
+
+# Optional: Enable TLS (default: true)
+# upstash_tls_enabled = true
+
+# =============================================================================
+# Application Secrets
+# =============================================================================
+
+# REQUIRED: JWT secret for authentication
+# Generate with: openssl rand -base64 32
+jwt_secret = "your-jwt-secret-here"
+
+# REQUIRED: Encryption key for sensitive data
+# Generate with: openssl rand -base64 32
+encryption_key = "your-encryption-key-here"

--- a/infra/upstash.tf
+++ b/infra/upstash.tf
@@ -1,0 +1,36 @@
+# Folk Care Upstash Redis Configuration
+
+# =============================================================================
+# Production Redis Database
+# =============================================================================
+
+resource "upstash_redis_database" "production" {
+  database_name = "${local.project_name}-production"
+  region        = var.upstash_region
+  tls           = var.upstash_tls_enabled
+  eviction      = var.upstash_eviction_enabled
+
+  # Multi-zone for high availability in production
+  multi_zone = true
+
+  # Cost control: set a budget limit
+  # Default $20/month, increase as needed
+  auto_scale = true
+}
+
+# =============================================================================
+# Preview Redis Database
+# =============================================================================
+
+resource "upstash_redis_database" "preview" {
+  database_name = "${local.project_name}-preview"
+  region        = var.upstash_region
+  tls           = var.upstash_tls_enabled
+  eviction      = var.upstash_eviction_enabled
+
+  # Single zone is sufficient for preview
+  multi_zone = false
+
+  # Cost control for preview
+  auto_scale = false
+}

--- a/infra/upstash.tf
+++ b/infra/upstash.tf
@@ -16,6 +16,10 @@ resource "upstash_redis_database" "production" {
   # Cost control: set a budget limit
   # Default $20/month, increase as needed
   auto_scale = true
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 # =============================================================================

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,103 @@
+# Folk Care Terraform Variables
+
+# =============================================================================
+# Vercel Configuration
+# =============================================================================
+
+variable "vercel_team_id" {
+  description = "Vercel team ID (optional, for team deployments)"
+  type        = string
+  default     = null
+}
+
+variable "vercel_git_repo" {
+  description = "GitHub repository for Vercel project"
+  type = object({
+    type              = string
+    repo              = string
+    production_branch = string
+  })
+  default = {
+    type              = "github"
+    repo              = "neighborhood-lab/folk-care"
+    production_branch = "production"
+  }
+}
+
+# =============================================================================
+# Neon Database Configuration
+# =============================================================================
+
+variable "neon_org_id" {
+  description = "Neon organization ID (required to prevent duplicate projects)"
+  type        = string
+  sensitive   = true
+}
+
+variable "neon_region" {
+  description = "Neon database region"
+  type        = string
+  default     = "aws-us-east-1"
+}
+
+variable "neon_compute_size" {
+  description = "Compute size for Neon endpoints (CU = Compute Units)"
+  type = object({
+    min_cu = number
+    max_cu = number
+  })
+  default = {
+    min_cu = 0.25
+    max_cu = 2
+  }
+}
+
+variable "neon_history_retention" {
+  description = "Point-in-time recovery history retention in seconds (default 7 days)"
+  type        = number
+  default     = 604800 # 7 days
+}
+
+# =============================================================================
+# Upstash Redis Configuration
+# =============================================================================
+
+variable "upstash_region" {
+  description = "Upstash Redis region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "upstash_tls_enabled" {
+  description = "Enable TLS for Upstash Redis connections"
+  type        = bool
+  default     = true
+}
+
+variable "upstash_eviction_enabled" {
+  description = "Enable eviction when database reaches max size"
+  type        = bool
+  default     = true
+}
+
+# =============================================================================
+# Environment Configuration
+# =============================================================================
+
+variable "environments" {
+  description = "List of environments to create (production, preview)"
+  type        = list(string)
+  default     = ["production", "preview"]
+}
+
+variable "jwt_secret" {
+  description = "JWT secret for authentication (generate with: openssl rand -base64 32)"
+  type        = string
+  sensitive   = true
+}
+
+variable "encryption_key" {
+  description = "Encryption key for sensitive data (generate with: openssl rand -base64 32)"
+  type        = string
+  sensitive   = true
+}

--- a/infra/vercel.tf
+++ b/infra/vercel.tf
@@ -1,0 +1,144 @@
+# Folk Care Vercel Project Configuration
+
+# =============================================================================
+# Vercel Project
+# =============================================================================
+
+resource "vercel_project" "folkcare" {
+  name      = local.project_name
+  framework = "vite"
+
+  git_repository = {
+    type              = var.vercel_git_repo.type
+    repo              = var.vercel_git_repo.repo
+    production_branch = var.vercel_git_repo.production_branch
+  }
+
+  # Build settings
+  build_command    = "npm run vercel:build"
+  output_directory = "public"
+  install_command  = "npm ci"
+  root_directory   = null
+
+  # Serverless function configuration
+  serverless_function_region = "iad1" # US East (N. Virginia)
+
+  # Enable automatic preview deployments
+  git_comments = {
+    on_pull_request = true
+    on_commit       = true
+  }
+
+  # Protection bypass for automation
+  protection_bypass_for_automation = true
+}
+
+# =============================================================================
+# Environment Variables - Production
+# =============================================================================
+
+resource "vercel_project_environment_variable" "database_url_production" {
+  project_id = vercel_project.folkcare.id
+  key        = "DATABASE_URL"
+  value      = neon_branch.production.connection_uri
+  target     = ["production"]
+}
+
+resource "vercel_project_environment_variable" "redis_url_production" {
+  project_id = vercel_project.folkcare.id
+  key        = "REDIS_URL"
+  value      = "rediss://${upstash_redis_database.production.endpoint}:${upstash_redis_database.production.port}"
+  target     = ["production"]
+}
+
+resource "vercel_project_environment_variable" "redis_token_production" {
+  project_id = vercel_project.folkcare.id
+  key        = "REDIS_TOKEN"
+  value      = upstash_redis_database.production.password
+  target     = ["production"]
+}
+
+resource "vercel_project_environment_variable" "jwt_secret_production" {
+  project_id = vercel_project.folkcare.id
+  key        = "JWT_SECRET"
+  value      = var.jwt_secret
+  target     = ["production"]
+}
+
+resource "vercel_project_environment_variable" "encryption_key_production" {
+  project_id = vercel_project.folkcare.id
+  key        = "ENCRYPTION_KEY"
+  value      = var.encryption_key
+  target     = ["production"]
+}
+
+resource "vercel_project_environment_variable" "node_env_production" {
+  project_id = vercel_project.folkcare.id
+  key        = "NODE_ENV"
+  value      = "production"
+  target     = ["production"]
+}
+
+# =============================================================================
+# Environment Variables - Preview
+# =============================================================================
+
+resource "vercel_project_environment_variable" "database_url_preview" {
+  project_id = vercel_project.folkcare.id
+  key        = "DATABASE_URL"
+  value      = neon_branch.preview.connection_uri
+  target     = ["preview", "development"]
+}
+
+resource "vercel_project_environment_variable" "redis_url_preview" {
+  project_id = vercel_project.folkcare.id
+  key        = "REDIS_URL"
+  value      = "rediss://${upstash_redis_database.preview.endpoint}:${upstash_redis_database.preview.port}"
+  target     = ["preview", "development"]
+}
+
+resource "vercel_project_environment_variable" "redis_token_preview" {
+  project_id = vercel_project.folkcare.id
+  key        = "REDIS_TOKEN"
+  value      = upstash_redis_database.preview.password
+  target     = ["preview", "development"]
+}
+
+resource "vercel_project_environment_variable" "jwt_secret_preview" {
+  project_id = vercel_project.folkcare.id
+  key        = "JWT_SECRET"
+  value      = var.jwt_secret
+  target     = ["preview", "development"]
+}
+
+resource "vercel_project_environment_variable" "encryption_key_preview" {
+  project_id = vercel_project.folkcare.id
+  key        = "ENCRYPTION_KEY"
+  value      = var.encryption_key
+  target     = ["preview", "development"]
+}
+
+resource "vercel_project_environment_variable" "node_env_preview" {
+  project_id = vercel_project.folkcare.id
+  key        = "NODE_ENV"
+  value      = "preview"
+  target     = ["preview", "development"]
+}
+
+# =============================================================================
+# Domain Configuration
+# =============================================================================
+
+resource "vercel_project_domain" "production" {
+  project_id = vercel_project.folkcare.id
+  domain     = "folk.care"
+}
+
+resource "vercel_project_domain" "www" {
+  project_id = vercel_project.folkcare.id
+  domain     = "www.folk.care"
+
+  # Redirect www to apex domain
+  redirect             = vercel_project_domain.production.domain
+  redirect_status_code = 308
+}

--- a/infra/vercel.tf
+++ b/infra/vercel.tf
@@ -40,7 +40,7 @@ resource "vercel_project" "folkcare" {
 resource "vercel_project_environment_variable" "database_url_production" {
   project_id = vercel_project.folkcare.id
   key        = "DATABASE_URL"
-  value      = neon_branch.production.connection_uri
+  value      = data.neon_branch.main.connection_uri
   target     = ["production"]
 }
 


### PR DESCRIPTION
## Summary
- Add complete Terraform configuration for managing Folk Care infrastructure
- Configure Vercel project, Neon PostgreSQL, and Upstash Redis providers
- Include environment variable management and domain configuration
- Add comprehensive documentation for infrastructure management

## Resources Managed

| Provider | Resources |
|----------|-----------|
| **Vercel** | Project, environment variables, domains (folk.care, www.folk.care) |
| **Neon PostgreSQL** | Project, branches (production/preview), endpoints, databases |
| **Upstash Redis** | Production and preview databases with TLS |

## Files Added
- `infra/main.tf` - Provider configuration (Vercel, Neon, Upstash)
- `infra/variables.tf` - Input variables with defaults
- `infra/outputs.tf` - Output values for connection strings
- `infra/backend.tf` - State backend configuration options
- `infra/vercel.tf` - Vercel project and environment variables
- `infra/neon.tf` - Neon database branches and endpoints
- `infra/upstash.tf` - Redis databases for production/preview
- `infra/README.md` - Complete documentation
- `infra/terraform.tfvars.example` - Example variables file
- `infra/.gitignore` - Ignore state and secrets

## Benefits
- **Reproducible**: Infrastructure defined as code
- **Version controlled**: All changes tracked in git
- **Self-documenting**: README explains usage
- **Secure**: Secrets via environment variables, state excluded from git

## Test plan
- [ ] Review Terraform configuration files
- [ ] Verify gitleaks allowlist includes infra directory
- [ ] Manual validation of provider syntax

Closes #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)